### PR TITLE
Fix for DATA_STORAGE Error after update to 2024.11.0

### DIFF
--- a/custom_components/indego/config_flow.py
+++ b/custom_components/indego/config_flow.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 from homeassistant.helpers import config_entry_oauth2_flow
-from homeassistant.components.application_credentials import ClientCredential, async_import_client_credential, DOMAIN as AC_DOMAIN, DATA_STORAGE as AC_DATA_STORAGE
+from homeassistant.components.application_credentials import ClientCredential, async_import_client_credential, DOMAIN as AC_DOMAIN, DATA_COMPONENT as AC_DATA_STORAGE
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.config_entries import OptionsFlowWithConfigEntry, ConfigEntry
 from homeassistant.core import callback


### PR DESCRIPTION
After the update to HA Version 2024.11.0 an error occurs.
Changed Line 9 in conflig_flow.py from 
```
from homeassistant.components.application_credentials import ClientCredential, async_import_client_credential, DOMAIN as AC_DOMAIN, DATA_STORAGE as AC_DATA_STORAGE
``` 
to 
```
from homeassistant.components.application_credentials import ClientCredential, async_import_client_credential, DOMAIN as AC_DOMAIN, DATA_COMPONENT as AC_DATA_STORAGE
``` 

Used the latest dev branch for this PR