### PR TITLE
Fix alert sensor state and delete all alerts handling

### DIFF
--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -3135,23 +3135,27 @@ class IndegoHub:
         self._update_alert_state()
 
     def _update_alert_state(self):
-        """Set alert sensor state based on current active error code, not just unread status."""
+        """Set alert sensor state based on current active error code and unread alerts."""
         if ENTITY_ALERT not in self.entities:
             return
 
         # Check if state is available and has 'error' attribute, otherwise default to 0 (no error)
-        current_error = getattr(self._indego_client.state, "error", 0)
+        current_error = getattr(
+            getattr(self._indego_client, "state", None),
+            "error",
+            None,
+        )
 
-        # If there are no active errors (current_error == 0) but the mower state is None, check for unread alerts to determine if we should show a problem state
-        if current_error == 0 and self._indego_client.state is None:
-            unread_count = sum(
-                1 for alert in self._indego_client.alerts
-                if str(alert.read_status).strip().lower() == "unread"
-            )
-            self.entities[ENTITY_ALERT].state = unread_count > 0
-        else:
-            # Show "Problem" if there is an active error code, otherwise "OK"
-            self.entities[ENTITY_ALERT].state = current_error != 0
+        unread_count = sum(
+            1 for alert in (self._indego_client.alerts or [])
+            if str(alert.read_status).strip().lower() == "unread"
+        )
+
+        # Show "Problem" if there is an active error code, otherwise "OK"
+        self.entities[ENTITY_ALERT].state = (
+            current_error not in (None, 0, "0")
+            or unread_count > 0
+        )
 
     async def _update_updates_available(self):
         await self._indego_client.update_updates_available()

--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -1314,7 +1314,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         await instance._update_alerts()
         await instance._indego_client.delete_alert(index)
-        await instance._update_alerts()
+        await instance._update_alerts(force_alert_state=True)
 
     async def async_delete_alert_all(call):
         """Handle the service call."""
@@ -1353,7 +1353,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await instance._indego_client.delete_all_alerts()
             await asyncio.sleep(5)
 
-        await instance._update_alerts()
+        await instance._update_alerts(force_alert_state=True)
 
     async def async_read_alert(call):
         """Handle the service call."""
@@ -1363,7 +1363,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         await instance._update_alerts()
         await instance._indego_client.put_alert_read(index)
-        await instance._update_alerts()
+        await instance._update_alerts(force_alert_state=True)
 
     async def async_read_alert_all(call):
         """Handle the service call."""
@@ -1372,7 +1372,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         await instance._update_alerts()
         await instance._indego_client.put_all_alerts_read()
-        await instance._update_alerts()
+        await instance._update_alerts(force_alert_state=True)
 
     async def async_download_map(call):
         """Handle the download_map service call."""
@@ -1589,6 +1589,7 @@ class IndegoHub:
         self._refresh_24h_remover = None
         self._shutdown = False
         self._latest_alert = None
+        self._empty_alert_refresh_count = 0
         self.entities = {}
         self._update_fail_count = None
         self._lawn_map = None
@@ -2723,8 +2724,6 @@ class IndegoHub:
             # Mark service as UP on successful response
             self.set_service_status(True)
 
-            self._update_alert_state()
-
             # Check for offline error codes (WiFi lost, API error, No connection to server)
             state_code = getattr(self._indego_client.state, 'state', None)
             if state_code in (802, 803, 804):
@@ -3060,16 +3059,9 @@ class IndegoHub:
 
         return self._indego_client.generic_data
 
-    async def _update_alerts(self):
+    async def _update_alerts(self, force_alert_state: bool = False):
 
         await self._indego_client.update_alerts()
-
-        # Show "Problem" only if there are unread alerts
-        unread_count = sum(
-            1 for alert in self._indego_client.alerts
-            if str(alert.read_status).strip().lower() == "unread"
-        )
-        self.entities[ENTITY_ALERT].state = unread_count > 0
 
         if self._indego_client.alerts:
             # Build complete alert attributes with enhanced error descriptions
@@ -3132,30 +3124,46 @@ class IndegoHub:
             while self.entities[ENTITY_ALERT].clear_attribute(f"error_{error_index}_code", False):
                 error_index += 1
 
-        self._update_alert_state()
+        self._update_alert_state(force=force_alert_state)
 
-    def _update_alert_state(self):
-        """Set alert sensor state based on current active error code and unread alerts."""
+    def _update_alert_state(self, force: bool = False):
+        """Update alert state based on unread alerts."""
         if ENTITY_ALERT not in self.entities:
             return
-
-        # Check if state is available and has 'error' attribute, otherwise default to 0 (no error)
-        current_error = getattr(
-            getattr(self._indego_client, "state", None),
-            "error",
-            None,
+    
+        alerts = self._indego_client.alerts or []
+    
+        has_unread_alerts = any(
+            str(alert.read_status).strip().lower() == "unread"
+            for alert in alerts
         )
-
-        unread_count = sum(
-            1 for alert in (self._indego_client.alerts or [])
-            if str(alert.read_status).strip().lower() == "unread"
-        )
-
-        # Show "Problem" if there is an active error code, otherwise "OK"
-        self.entities[ENTITY_ALERT].state = (
-            current_error not in (None, 0, "0")
-            or unread_count > 0
-        )
+    
+        if has_unread_alerts:
+            # At least one unread alert exists.
+            self._empty_alert_refresh_count = 0
+            self.entities[ENTITY_ALERT].state = True
+            return
+    
+        if alerts:
+            # Alerts exist, but all of them have been read.
+            self._empty_alert_refresh_count = 0
+            self.entities[ENTITY_ALERT].state = False
+            return
+    
+        if force:
+            # An explicit read/delete operation was performed.
+            # Accept the empty alert list immediately.
+            self._empty_alert_refresh_count = 0
+            self.entities[ENTITY_ALERT].state = False
+            return
+    
+        # Bosch may occasionally return an empty alert list during
+        # periodic refreshes. Require two consecutive empty responses
+        # before clearing the problem state.
+        self._empty_alert_refresh_count += 1
+    
+        if self._empty_alert_refresh_count >= 2:
+            self.entities[ENTITY_ALERT].state = False
 
     async def _update_updates_available(self):
         await self._indego_client.update_updates_available()


### PR DESCRIPTION
## Summary

Fixes incorrect/flapping states of the alert binary sensor and improves alert state handling after read/delete operations.

## Changes

- Determine the alert binary sensor state from unread alerts.
- Ignore a single unexpectedly empty alert response to prevent state flapping caused by temporary empty responses from the Bosch API.
- Require two consecutive empty alert responses before automatically clearing the alert state.
- Immediately update the alert state after explicit read/delete operations.
- Improve `delete_all_alerts` handling by refreshing the alert list until all alerts are removed.
- Remove dependency on `state.error`, as it may be stale or unavailable even when alerts exist.

Explicit read/delete actions bypass the empty-response protection so the binary sensor is updated immediately after a user action.

Fixes #306