### PR TITLE
Add mower entity targeting to services

### DIFF
--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -77,38 +77,46 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_SCHEMA_COMMAND = vol.Schema({
     vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Optional(CONF_MOWER_ENTITY): cv.entity_id,
     vol.Required(CONF_SEND_COMMAND): cv.string
 })
 
 SERVICE_SCHEMA_SMARTMOWING = vol.Schema({
     vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Optional(CONF_MOWER_ENTITY): cv.entity_id,
     vol.Required(CONF_SMARTMOWING): cv.boolean
 })
 
 SERVICE_SCHEMA_DELETE_ALERT = vol.Schema({
     vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Optional(CONF_MOWER_ENTITY): cv.entity_id,
     vol.Required(SERVER_DATA_ALERT_INDEX): cv.positive_int
 })
 
 SERVICE_SCHEMA_DELETE_ALERT_ALL = vol.Schema({
-    vol.Optional(CONF_MOWER_SERIAL): cv.string
+    vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Optional(CONF_MOWER_ENTITY): cv.entity_id
 })
 
 SERVICE_SCHEMA_READ_ALERT = vol.Schema({
     vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Optional(CONF_MOWER_ENTITY): cv.entity_id,
     vol.Required(SERVER_DATA_ALERT_INDEX): cv.positive_int
 })
 
 SERVICE_SCHEMA_READ_ALERT_ALL = vol.Schema({
-    vol.Optional(CONF_MOWER_SERIAL): cv.string
+    vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Optional(CONF_MOWER_ENTITY): cv.entity_id
 })
 
 SERVICE_SCHEMA_DOWNLOAD_MAP = vol.Schema({
-    vol.Optional(CONF_MOWER_SERIAL): cv.string
+    vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Optional(CONF_MOWER_ENTITY): cv.entity_id
 })
 
 SERVICE_SCHEMA_SET_CALENDAR_SLOT = vol.Schema({
     vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Optional(CONF_MOWER_ENTITY): cv.entity_id,
     vol.Required(CONF_DAYS): vol.All(
         cv.ensure_list,
         [vol.In([
@@ -124,12 +132,14 @@ SERVICE_SCHEMA_SET_CALENDAR_SLOT = vol.Schema({
 
 SERVICE_SCHEMA_SET_PREDICTIVE_MOWING_WINDOW = vol.Schema({
     vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Optional(CONF_MOWER_ENTITY): cv.entity_id,
     vol.Required(CONF_EARLIEST_START): cv.string,
     vol.Required(CONF_LATEST_END): cv.string,
 })
 
 SERVICE_SCHEMA_SET_BUMP_SENSITIVITY = vol.Schema({
     vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Optional(CONF_MOWER_ENTITY): cv.entity_id,
     vol.Required(CONF_BUMP_SENSITIVITY): vol.In([
         "normal",
         "slippery",
@@ -139,6 +149,7 @@ SERVICE_SCHEMA_SET_BUMP_SENSITIVITY = vol.Schema({
 
 SERVICE_SCHEMA_SET_PIN = vol.Schema({
     vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Optional(CONF_MOWER_ENTITY): cv.entity_id,
     vol.Required(CONF_PIN): vol.All(
         cv.string,
         vol.Length(min=4, max=4),
@@ -1287,7 +1298,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.warning("Error setting up features: %s", err)
 
     def find_instance_for_mower_service_call(call):
+        mower_entity = call.data.get(CONF_MOWER_ENTITY, None)
         mower_serial = call.data.get(CONF_MOWER_SERIAL, None)
+        
+        if mower_entity is not None:
+            for config_entry_id in hass.data[DOMAIN]:
+                if config_entry_id == CONF_SERVICES_REGISTERED:
+                    continue
+
+                instance = hass.data[DOMAIN][config_entry_id]
+                expected_entity_id = f"lawn_mower.indego_{instance.serial}"
+
+                if mower_entity == expected_entity_id:
+                    return instance
+
+            raise HomeAssistantError(
+                "No mower instance found for entity '%s'" % mower_entity
+            )
+
         if mower_serial is None:
             # Return the first instance when params is missing for backwards compatibility.
             return hass.data[DOMAIN][hass.data[DOMAIN][CONF_SERVICES_REGISTERED]]

--- a/custom_components/indego/const.py
+++ b/custom_components/indego/const.py
@@ -14,6 +14,7 @@ DATA_UPDATED: Final = f"{DOMAIN}_data_updated"
 
 CONF_MOWER_SERIAL: Final = "mower_serial"
 CONF_MOWER_NAME: Final = "mower_name"
+CONF_MOWER_ENTITY: Final = "mower_entity"
 CONF_EXPOSE_INDEGO_AS_MOWER: Final = "expose_mower"
 CONF_EXPOSE_INDEGO_AS_VACUUM: Final = "expose_vacuum"
 CONF_SHOW_ALL_ALERTS: Final = "show_all_alerts"

--- a/custom_components/indego/services.yaml
+++ b/custom_components/indego/services.yaml
@@ -8,6 +8,14 @@ command:
       required: false
       selector:
         text: {}
+    mower_entity:
+      name: Entity
+      description: Select the mower entity. Only required if multiple mowers are configured.
+      required: false
+      selector:
+        entity:
+          domain: lawn_mower
+          integration: indego
     command:
       name: Command
       description: Command to send to the mower.
@@ -19,6 +27,7 @@ command:
             - "mow"
             - "returnToDock"
             - "pause"
+
 smartmowing:
   description: Enables or disables the SmartMowing feature, which automatically adjusts the mowing schedule based on weather conditions and lawn growth.
   fields:
@@ -29,6 +38,14 @@ smartmowing:
       required: false
       selector:
         text: {}
+    mower_entity:
+      name: Entity
+      description: Select the mower entity. Only required if multiple mowers are configured.
+      required: false
+      selector:
+        entity:
+          domain: lawn_mower
+          integration: indego
     enable:
       name: Activate/Deactivate
       description: Sets the SmartMowing state. Use "true" to enable or "false" to disable the feature.
@@ -36,6 +53,7 @@ smartmowing:
       required: true
       selector:
         boolean: {}
+
 delete_alert:
   description: Deletes a specific alert by its index. Index 0 refers to the most recent alert.
   fields:
@@ -46,13 +64,25 @@ delete_alert:
       required: false
       selector:
         text: {}
+    mower_entity:
+      name: Entity
+      description: Select the mower entity. Only required if multiple mowers are configured.
+      required: false
+      selector:
+        entity:
+          domain: lawn_mower
+          integration: indego
     alert_index:
       name: Alert index
       description: Index of the alert to delete. 0 = most recent, 1 = second most recent, and so on.
-      example: "0"
+      example: 0
       required: true
       selector:
-        text: {}
+        number:
+          min: 0
+          step: 1
+          mode: box
+
 delete_alert_all:
   description: Deletes all existing alerts for the mower at once.
   fields:
@@ -63,6 +93,15 @@ delete_alert_all:
       required: false
       selector:
         text: {}
+    mower_entity:
+      name: Entity
+      description: Select the mower entity. Only required if multiple mowers are configured.
+      required: false
+      selector:
+        entity:
+          domain: lawn_mower
+          integration: indego
+
 read_alert:
   description: Marks a specific alert as read by its index. Index 0 refers to the most recent alert.
   fields:
@@ -73,13 +112,25 @@ read_alert:
       required: false
       selector:
         text: {}
+    mower_entity:
+      name: Entity
+      description: Select the mower entity. Only required if multiple mowers are configured.
+      required: false
+      selector:
+        entity:
+          domain: lawn_mower
+          integration: indego
     alert_index:
       name: Alert Index
       description: Index of the alert to mark as read. 0 = most recent, 1 = second most recent, and so on.
-      example: "0"
+      example: 0
       required: true
       selector:
-        text: {}
+        number:
+          min: 0
+          step: 1
+          mode: box
+
 read_alert_all:
   description: Marks all existing alerts for the mower as read.
   fields:
@@ -90,6 +141,15 @@ read_alert_all:
       required: false
       selector:
         text: {}
+    mower_entity:
+      name: Entity
+      description: Select the mower entity. Only required if multiple mowers are configured.
+      required: false
+      selector:
+        entity:
+          domain: lawn_mower
+          integration: indego
+
 download_map:
   description: Downloads the current mowing map from the Bosch Cloud API and saves it locally as "www/indego_map_base.svg". The map reflects the most recently recorded mowing route.
   fields:
@@ -100,8 +160,17 @@ download_map:
       required: false
       selector:
         text: {}
+    mower_entity:
+      name: Entity
+      description: Select the mower entity. Only required if multiple mowers are configured.
+      required: false
+      selector:
+        entity:
+          domain: lawn_mower
+          integration: indego
+
 set_calendar_slot:
-  description: Set a calender slot when you use the manual calendar instead of SmartMowing.
+  description: Set a calendar slot when you use a manual schedule instead of SmartMowing.
   fields:
     mower_serial:
       name: Serialnumber
@@ -110,9 +179,17 @@ set_calendar_slot:
       required: false
       selector:
         text: {}
+    mower_entity:
+      name: Entity
+      description: Select the mower entity. Only required if multiple mowers are configured.
+      required: false
+      selector:
+        entity:
+          domain: lawn_mower
+          integration: indego
     days:
       name: Days
-      description: Which day to configure.
+      description: Which days to configure.
       example: "monday"
       required: true
       selector:
@@ -129,8 +206,8 @@ set_calendar_slot:
             - "sunday"
     slot:
       name: Slot
-      description: Which Slot of the selected day should be configured (1 or 2).
-      example: "1"
+      description: Which slot of the selected day should be configured (1 or 2).
+      example: 1
       required: true
       selector:
         number:
@@ -141,21 +218,21 @@ set_calendar_slot:
     enabled:
       name: Activate/Deactivate
       description: Should the selected slot be enabled or disabled.
-      example: "true"
+      example: true
       required: false
       selector:
         boolean: {}
     start:
       name: Start time
-      description: Set Start Time of the selected slot and day. Only needed if you want to enable a slot. Only hour and minute will be used.
-      example: '"08:00"'
+      description: Set the start time of the selected slot and day. Only needed if you want to enable a slot. Only hour and minute will be used.
+      example: "08:00"
       required: false
       selector:
         time: {}
     end:
       name: End time
-      description: Set End Time of the selected slot and day. Only needed if you want to enable a slot. Only hour and minute will be used.
-      example: '"20:00"'
+      description: Set the end time of the selected slot and day. Only needed if you want to enable a slot. Only hour and minute will be used.
+      example: "20:00"
       required: false
       selector:
         time: {}
@@ -170,7 +247,14 @@ set_predictive_mowing_window:
       required: false
       selector:
         text: {}
-
+    mower_entity:
+      name: Entity
+      description: Select the mower entity. Only required if multiple mowers are configured.
+      required: false
+      selector:
+        entity:
+          domain: lawn_mower
+          integration: indego
     earliest_start:
       name: Earliest start
       description: Earliest time SmartMowing is allowed to mow. Only hours and minutes are used.
@@ -178,7 +262,6 @@ set_predictive_mowing_window:
       required: true
       selector:
         time: {}
-
     latest_end:
       name: Latest end
       description: Latest time SmartMowing is allowed to mow. Only hours and minutes are used.
@@ -197,7 +280,14 @@ set_bump_sensitivity:
       required: false
       selector:
         text: {}
-
+    mower_entity:
+      name: Entity
+      description: Select the mower entity. Only required if multiple mowers are configured.
+      required: false
+      selector:
+        entity:
+          domain: lawn_mower
+          integration: indego
     bump_sensitivity:
       name: Bump sensitivity
       description: Bump sensitivity of the mower.
@@ -213,14 +303,21 @@ set_bump_sensitivity:
 set_pin:
   name: Change mower PIN
   description: Change the mower PIN.
-
   fields:
     mower_serial:
       name: Serial number
+      description: Serial number of the mower. Only required if multiple mowers are configured.
       required: false
       selector:
         text: {}
-
+    mower_entity:
+      name: Entity
+      description: Select the mower entity. Only required if multiple mowers are configured.
+      required: false
+      selector:
+        entity:
+          domain: lawn_mower
+          integration: indego
     pin:
       name: PIN
       description: New 4-digit mower PIN.

--- a/custom_components/indego/translations/da.json
+++ b/custom_components/indego/translations/da.json
@@ -682,167 +682,207 @@
     "services": {
         "command": {
             "name": "Send kommando",
-            "description": "Send kommandoer til græsslåmaskinen. Vælg en kommando.",
+            "description": "Send kommandoer til græsslåmaskinen. Gyldige kommandoer er \"mow\" (start klipning), \"returnToDock\" (retur til ladestation) og \"pause\" (pause klipning).",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                    "description": "Serienummer på græsslåmaskinen. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
+                },
+                "mower_entity": {
+                    "name": "Enhed",
+                    "description": "Vælg græsslåmaskine-enheden. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
                 },
                 "command": {
-                    "name": "Send kommando",
-                    "description": "Send kommandoer til græsslåmaskinen. Vælg en kommando."
+                    "name": "Kommando",
+                    "description": "Kommando, der skal sendes til græsslåmaskinen."
                 }
             }
         },
         "smartmowing": {
             "name": "Skift SmartMowing",
-            "description": "Aktivér eller deaktivér SmartMowing. Tilladte værdier er true eller false.",
+            "description": "Aktivér eller deaktivér SmartMowing-funktionen, som automatisk justerer klipningsplanen baseret på vejrforhold og græsvækst.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                    "description": "Serienummer på græsslåmaskinen. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
+                },
+                "mower_entity": {
+                    "name": "Enhed",
+                    "description": "Vælg græsslåmaskine-enheden. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
                 },
                 "enable": {
-                    "name": "Aktivér",
-                    "description": "Aktivér SmartMowing."
+                    "name": "Aktivér/deaktivér",
+                    "description": "Angiv SmartMowing-tilstand. Brug \"true\" for at aktivere eller \"false\" for at deaktivere funktionen."
                 }
             }
         },
         "delete_alert": {
             "name": "Slet advarsel",
-            "description": "Slet den valgte advarsel.",
+            "description": "Sletter en specifik advarsel baseret på dens indeks. Indeks 0 refererer til den seneste advarsel.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                    "description": "Serienummer på græsslåmaskinen. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
+                },
+                "mower_entity": {
+                    "name": "Enhed",
+                    "description": "Vælg græsslåmaskine-enheden. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
                 },
                 "alert_index": {
                     "name": "Advarselsindeks",
-                    "description": "Slet den valgte advarsel. 0 for den seneste advarsel."
+                    "description": "Indeks for den advarsel, der skal slettes. 0 = seneste, 1 = næstseneste osv."
                 }
             }
         },
         "delete_alert_all": {
             "name": "Slet alle advarsler",
-            "description": "Slet alle advarsler.",
+            "description": "Sletter alle eksisterende advarsler for græsslåmaskinen på én gang.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                    "description": "Serienummer på græsslåmaskinen. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
+                },
+                "mower_entity": {
+                    "name": "Enhed",
+                    "description": "Vælg græsslåmaskine-enheden. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
                 }
             }
         },
         "read_alert": {
             "name": "Marker advarsel som læst",
-            "description": "Markér den valgte advarsel som læst.",
+            "description": "Markerer en specifik advarsel som læst baseret på dens indeks. Indeks 0 refererer til den seneste advarsel.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                    "description": "Serienummer på græsslåmaskinen. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
+                },
+                "mower_entity": {
+                    "name": "Enhed",
+                    "description": "Vælg græsslåmaskine-enheden. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
                 },
                 "alert_index": {
                     "name": "Advarselsindeks",
-                    "description": "Markér den valgte advarsel som læst. 0 for den seneste advarsel."
+                    "description": "Indeks for den advarsel, der skal markeres som læst. 0 = seneste, 1 = næstseneste osv."
                 }
             }
         },
         "read_alert_all": {
             "name": "Marker alle advarsler som læst",
-            "description": "Markér alle advarsler som læste.",
+            "description": "Markerer alle eksisterende advarsler for græsslåmaskinen som læst.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                    "description": "Serienummer på græsslåmaskinen. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
+                },
+                "mower_entity": {
+                    "name": "Enhed",
+                    "description": "Vælg græsslåmaskine-enheden. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
                 }
             }
         },
         "download_map": {
-            "name": "Download klippekort",
-            "description": "Henter det aktuelle slåningskort fra Bosch Cloud API'en og gemmer det lokalt som \"www/indego_map_base.svg\". Kortet afspejler den senest optegnede slåningsrute.",
+            "name": "Download klipningskort",
+            "description": "Henter det aktuelle klipningskort fra Bosch Cloud API og gemmer det lokalt som \"www/indego_map_base.svg\". Kortet afspejler den senest registrerede klipningsrute.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                    "description": "Serienummer på græsslåmaskinen. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
+                },
+                "mower_entity": {
+                    "name": "Enhed",
+                    "description": "Vælg græsslåmaskine-enheden. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
                 }
             }
         },
         "set_calendar_slot": {
             "name": "Aktivér/deaktivér kalender-slot",
-            "description": "Rediger en kalender-slot (ændr tider, aktivér eller deaktivér)",
+            "description": "Angiv et kalender-slot, når du bruger en manuel tidsplan i stedet for SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Serienummer på plæneklipperen. Kun nødvendig, hvis der er konfigureret flere plæneklippere."
+                    "description": "Serienummer på græsslåmaskinen. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
                 },
-                "calendar_type": {
-                    "name": "Kalendertype",
-                    "description": "Vælg kalender ('calendar' for manuel kalender oder 'predictive' for deaktiverede tidsrum i SmartMowing-tilstand)."
+                "mower_entity": {
+                    "name": "Enhed",
+                    "description": "Vælg græsslåmaskine-enheden. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
                 },
                 "days": {
-                    "name": "Dag",
-                    "description": "Navnet på den ugedag, der skal konfigureres."
+                    "name": "Dage",
+                    "description": "Hvilken dag der skal konfigureres."
                 },
                 "slot": {
-                    "name": "Tidsslot",
-                    "description": "Hvilken tidsslot skal ændres (1 eller 2)."
+                    "name": "Slot",
+                    "description": "Hvilket slot på den valgte dag der skal konfigureres (1 eller 2)."
                 },
                 "enabled": {
                     "name": "Aktivér/deaktivér",
-                    "description": "Aktivér eller deaktivér den valgte dag/slot."
+                    "description": "Skal det valgte slot være aktiveret eller deaktiveret."
                 },
                 "start": {
-                    "name": "Start",
-                    "description": "Starttidspunkt for den valgte slot. Kun nødvendigt hvis slotten skal aktiveres. Kun timer og minutter anvendes."
+                    "name": "Starttidspunkt",
+                    "description": "Angiv starttidspunkt for det valgte slot og dag. Kun nødvendigt, hvis du vil aktivere et slot. Kun time og minut bruges."
                 },
                 "end": {
-                    "name": "Slut",
-                    "description": "Sluttidspunkt for den valgte slot. Kun nødvendigt hvis slotten skal aktiveres. Kun timer og minutter anvendes."
-                }
-            }
-        },
-        "set_bump_sensitivity": {
-            "name": "Indstil plæneforhold for plæneklipperen",
-            "description": "Indstil plæneforholdene for plæneklipperen",
-            "fields": {
-                "mower_serial": {
-                    "name": "Serienummer",
-                    "description": "Plæneklipperens serienummer. Kun påkrævet hvis flere plæneklippere er konfigureret."
-                },
-                "bump_sensitivity": {
-                    "name": "Plæneforhold",
-                    "description": "Plæneforhold for plæneklipperen"
-                }
-            }
-        },
-        "set_pin": {
-            "name": "PIN-kode",
-            "description": "Skift plæneklipperens PIN-kode",
-            "fields": {
-                "mower_serial": {
-                    "name": "Serienummer",
-                    "description": "Plæneklipperens serienummer. Kun nødvendigt hvis flere plæneklippere er konfigureret."
-                },
-                "pin": {
-                    "name": "PIN-kode",
-                    "description": "Ny firecifret PIN-kode til plæneklipperen"
+                    "name": "Sluttidspunkt",
+                    "description": "Angiv sluttidspunkt for det valgte slot og dag. Kun nødvendigt, hvis du vil aktivere et slot. Kun time og minut bruges."
                 }
             }
         },
         "set_predictive_mowing_window": {
             "name": "Indstil tidsvindue for SmartMowing",
-            "description": "Tidsvinduet, hvor plæneklipperen må klippe i SmartMowing-tilstand.",
+            "description": "Angiv det tilladte klipningsvindue for SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Plæneklipperens serienummer. Kun nødvendigt, hvis flere plæneklippere er konfigureret."
+                    "description": "Serienummer på græsslåmaskinen. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
+                },
+                "mower_entity": {
+                    "name": "Enhed",
+                    "description": "Vælg græsslåmaskine-enheden. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
                 },
                 "earliest_start": {
                     "name": "Tidligste start",
-                    "description": "Det tidligste tidspunkt, hvor plæneklipperen skal starte."
+                    "description": "Tidligste tidspunkt, hvor SmartMowing må klippe. Kun timer og minutter bruges."
                 },
                 "latest_end": {
                     "name": "Seneste slut",
-                    "description": "Det seneste tidspunkt, hvor plæneklipperen skal være færdig."
+                    "description": "Seneste tidspunkt, hvor SmartMowing må klippe. Kun timer og minutter bruges."
+                }
+            }
+        },
+        "set_bump_sensitivity": {
+            "name": "Indstil plæneforhold",
+            "description": "Indstil plæneklipperens stødfølsomhed.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummer på græsslåmaskinen. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
+                },
+                "mower_entity": {
+                    "name": "Enhed",
+                    "description": "Vælg græsslåmaskine-enheden. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
+                },
+                "bump_sensitivity": {
+                    "name": "Stødfølsomhed",
+                    "description": "Plæneklipperens stødfølsomhed."
+                }
+            }
+        },
+        "set_pin": {
+            "name": "Skift PIN-kode",
+            "description": "Skift plæneklipperens PIN-kode.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummer på græsslåmaskinen. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
+                },
+                "mower_entity": {
+                    "name": "Enhed",
+                    "description": "Vælg græsslåmaskine-enheden. Kun nødvendigt, hvis flere græsslåmaskiner er konfigureret."
+                },
+                "pin": {
+                    "name": "PIN-kode",
+                    "description": "Ny 4-cifret PIN-kode til plæneklipperen."
                 }
             }
         }
@@ -868,9 +908,8 @@
         "command_options": {
             "options": {
                 "mow": "Klip græs",
-                "return_to_dock": "Tilbage til ladestationen",
-                "pause": "Pause",
-                "returnToDock": "Tilbage til ladestationen"
+                "returnToDock": "Tilbage til ladestationen",
+                "pause": "Pause"
             }
         },
         "bump_sensitivity_options": {

--- a/custom_components/indego/translations/da.json
+++ b/custom_components/indego/translations/da.json
@@ -190,7 +190,7 @@
             "mowing_mode": {
                 "name": "Klippemode",
                 "state": {
-                    "Calendar": "Manuel kalender"
+                    "calendar": "Manuel kalender"
                 }
             },
             "runtime_total": {
@@ -908,7 +908,7 @@
         "command_options": {
             "options": {
                 "mow": "Klip græs",
-                "returnToDock": "Tilbage til ladestationen",
+                "return_to_dock": "Tilbage til ladestationen",
                 "pause": "Pause"
             }
         },

--- a/custom_components/indego/translations/de.json
+++ b/custom_components/indego/translations/de.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Mähmodus",
                 "state": {
-                    "Calendar": "Kalender"
+                    "calendar": "Kalender"
                 }
             },
             "runtime_total": {
@@ -872,7 +872,7 @@
         "command_options": {
             "options": {
                 "mow": "Mähen",
-                "returnToDock": "Zurück zur Ladestation",
+                "return_to_dock": "Zurück zur Ladestation",
                 "pause": "Pause"
             }
         },

--- a/custom_components/indego/translations/de.json
+++ b/custom_components/indego/translations/de.json
@@ -646,167 +646,207 @@
     "services": {
         "command": {
             "name": "Befehl senden",
-            "description": "Befehle an den Mähroboter senden. Wählen Sie einen Befehl aus.",
+            "description": "Sendet einen Steuerbefehl an den Mähroboter. Gültige Befehle sind \"mow\" (Mähen starten), \"returnToDock\" (Rückkehr zur Ladestation) und \"pause\" (Mähen pausieren).",
             "fields": {
                 "mower_serial": {
                     "name": "Seriennummer",
-                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                    "description": "Seriennummer des Mähroboters. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
+                },
+                "mower_entity": {
+                    "name": "Entität",
+                    "description": "Wählen Sie die Mähroboter-Entität aus. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
                 },
                 "command": {
-                    "name": "Befehl senden",
-                    "description": "Befehle an den Mähroboter senden. Wählen Sie einen Befehl aus."
+                    "name": "Befehl",
+                    "description": "Der an den Mähroboter zu sendende Befehl."
                 }
             }
         },
         "smartmowing": {
             "name": "SmartMowing umschalten",
-            "description": "SmartMowing aktivieren oder deaktivieren. Mögliche Werte sind true oder false.",
+            "description": "Aktiviert oder deaktiviert die SmartMowing-Funktion, die den Mähplan automatisch an Wetterbedingungen und Rasenwachstum anpasst.",
             "fields": {
                 "mower_serial": {
                     "name": "Seriennummer",
-                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                    "description": "Seriennummer des Mähroboters. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
+                },
+                "mower_entity": {
+                    "name": "Entität",
+                    "description": "Wählen Sie die Mähroboter-Entität aus. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
                 },
                 "enable": {
                     "name": "Aktivieren/Deaktivieren",
-                    "description": "SmartMowing aktivieren."
+                    "description": "Legt den SmartMowing-Status fest. Verwenden Sie \"true\" zum Aktivieren oder \"false\" zum Deaktivieren."
                 }
             }
         },
         "delete_alert": {
-            "name": "Alert löschen",
-            "description": "Löscht den ausgewählten Fehler.",
+            "name": "Fehler löschen",
+            "description": "Löscht einen bestimmten Fehler anhand seines Index. Index 0 bezieht sich auf den neuesten Fehler.",
             "fields": {
                 "mower_serial": {
                     "name": "Seriennummer",
-                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                    "description": "Seriennummer des Mähroboters. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
+                },
+                "mower_entity": {
+                    "name": "Entität",
+                    "description": "Wählen Sie die Mähroboter-Entität aus. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
                 },
                 "alert_index": {
                     "name": "Fehler Index",
-                    "description": "Den ausgewählten Fehler löschen. Mit 0 wird der letzte/aktuellste Fehler gelöscht."
+                    "description": "Index des zu löschenden Fehlers. 0 = neuester, 1 = zweitneuester, usw."
                 }
             }
         },
         "delete_alert_all": {
-            "name": "Alle Alerts löschen",
-            "description": "Löscht alle Fehler.",
+            "name": "Alle Fehler löschen",
+            "description": "Löscht alle vorhandenen Fehler des Mähroboters auf einmal.",
             "fields": {
                 "mower_serial": {
                     "name": "Seriennummer",
-                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                    "description": "Seriennummer des Mähroboters. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
+                },
+                "mower_entity": {
+                    "name": "Entität",
+                    "description": "Wählen Sie die Mähroboter-Entität aus. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
                 }
             }
         },
         "read_alert": {
-            "name": "Alert als gelesen markieren",
-            "description": "Markiert den ausgewählten Fehler als gelesen.",
+            "name": "Fehler als gelesen markieren",
+            "description": "Markiert einen bestimmten Fehler anhand seines Index als gelesen. Index 0 bezieht sich auf den neuesten Fehler.",
             "fields": {
                 "mower_serial": {
                     "name": "Seriennummer",
-                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                    "description": "Seriennummer des Mähroboters. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
+                },
+                "mower_entity": {
+                    "name": "Entität",
+                    "description": "Wählen Sie die Mähroboter-Entität aus. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
                 },
                 "alert_index": {
                     "name": "Fehler Index",
-                    "description": "Den ausgewählten Fehler als gelesen markieren. Mit 0 wird der letzte/aktuellste Fehler ausgewählt."
+                    "description": "Index des als gelesen zu markierenden Fehlers. 0 = neuester, 1 = zweitneuester, usw."
                 }
             }
         },
         "read_alert_all": {
-            "name": "Alle Alerts als gelesen markieren",
-            "description": "Markiert alle Fehler als gelesen.",
+            "name": "Alle Fehler als gelesen markieren",
+            "description": "Markiert alle vorhandenen Fehler des Mähroboters als gelesen.",
             "fields": {
                 "mower_serial": {
                     "name": "Seriennummer",
-                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                    "description": "Seriennummer des Mähroboters. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
+                },
+                "mower_entity": {
+                    "name": "Entität",
+                    "description": "Wählen Sie die Mähroboter-Entität aus. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
                 }
             }
         },
         "download_map": {
             "name": "Mähkarte herunterladen",
-            "description": "Lädt die aktuelle Mähkarte von der Bosch Cloud API herunter und speichert diese lokal unter \"www/indego_map_base.svg\". Die Karte zeigt die zuletzt aufgezeichnete Mähroute.",
+            "description": "Lädt die aktuelle Mähkarte von der Bosch Cloud API herunter und speichert sie lokal unter \"www/indego_map_base.svg\". Die Karte zeigt die zuletzt aufgezeichnete Mähroute.",
             "fields": {
                 "mower_serial": {
                     "name": "Seriennummer",
-                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                    "description": "Seriennummer des Mähroboters. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
+                },
+                "mower_entity": {
+                    "name": "Entität",
+                    "description": "Wählen Sie die Mähroboter-Entität aus. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
                 }
             }
         },
         "set_calendar_slot": {
-            "name": "Kalender Slot aktivieren/deaktivieren",
-            "description": "Einen Kalender Slot verändern (Zeiten ändern, aktivieren oder deaktivieren)",
+            "name": "Kalender-Slot einstellen",
+            "description": "Legt einen Kalender-Slot fest, wenn Sie einen manuellen Zeitplan anstelle von SmartMowing verwenden.",
             "fields": {
                 "mower_serial": {
                     "name": "Seriennummer",
-                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                    "description": "Seriennummer des Mähroboters. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
                 },
-                "calendar_type": {
-                    "name": "Kalender Typ",
-                    "description": "Kalender auswählen ('calendar' für manuellen Kalender oder 'predictive' für deaktivierte Zeiten im SmartMowing Modus)."
+                "mower_entity": {
+                    "name": "Entität",
+                    "description": "Wählen Sie die Mähroboter-Entität aus. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
                 },
                 "days": {
-                    "name": "Tag",
-                    "description": "Name des Wochentags der konfiguriert werden soll"
+                    "name": "Tage",
+                    "description": "Welcher Wochentag konfiguriert werden soll."
                 },
                 "slot": {
-                    "name": "Zeitfenster",
-                    "description": "Welcher Zeitslot soll geändert werden (1 oder 2)"
+                    "name": "Slot",
+                    "description": "Welcher Slot des ausgewählten Tages konfiguriert werden soll (1 oder 2)."
                 },
                 "enabled": {
                     "name": "Aktivieren/Deaktivieren",
-                    "description": "Gewhälten Tag/Slot aktivieren/deaktivieren"
+                    "description": "Soll der ausgewählte Slot aktiviert oder deaktiviert werden."
                 },
                 "start": {
-                    "name": "Start",
-                    "description": "Startzeit des gewählten Slots. Wird nur benötigt wenn ein Zeitslot aktiviert werden soll. Nur Stunden und Minuten werden übernommen."
+                    "name": "Startzeit",
+                    "description": "Startzeit für den ausgewählten Slot und Tag. Nur erforderlich, wenn der Slot aktiviert werden soll. Es werden nur Stunden und Minuten verwendet."
                 },
                 "end": {
-                    "name": "Ende",
-                    "description": "Endzeit des gewählten Slots. Wird nur benötigt wenn ein Zeitslot aktiviert werden soll. Nur Stunden und Minuten werden übernommen."
+                    "name": "Endzeit",
+                    "description": "Endzeit für den ausgewählten Slot und Tag. Nur erforderlich, wenn der Slot aktiviert werden soll. Es werden nur Stunden und Minuten verwendet."
                 }
             }
         },
         "set_predictive_mowing_window": {
-            "name": "Zeitfenster für SmartMowing Zeiten setzen",
-            "description": "Das Zeitfenster in dem der Mäher im SmartMowing Modus mähen darf.",
+            "name": "SmartMowing-Zeitfenster festlegen",
+            "description": "Legt das erlaubte Mähzeitfenster für SmartMowing fest.",
             "fields": {
                 "mower_serial": {
                     "name": "Seriennummer",
-                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                    "description": "Seriennummer des Mähroboters. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
+                },
+                "mower_entity": {
+                    "name": "Entität",
+                    "description": "Wählen Sie die Mähroboter-Entität aus. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
                 },
                 "earliest_start": {
                     "name": "Frühester Start",
-                    "description": "Um wie viel Uhr soll der Mäher frühestens beginnen."
+                    "description": "Früheste Uhrzeit, zu der SmartMowing mähen darf. Es werden nur Stunden und Minuten verwendet."
                 },
                 "latest_end": {
                     "name": "Spätestes Ende",
-                    "description": "Um wie viel uhr soll der Mäher spätestens beenden."
+                    "description": "Späteste Uhrzeit, zu der SmartMowing mähen darf. Es werden nur Stunden und Minuten verwendet."
                 }
             }
         },
         "set_bump_sensitivity": {
-            "name": "Rasenbedingungen des Mähers einstellen",
-            "description": "Die Rasenbedingungen des Mähers einstellen",
+            "name": "Rasenbedingungen einstellen",
+            "description": "Stellt die Stoßempfindlichkeit des Mähroboters ein.",
             "fields": {
                 "mower_serial": {
                     "name": "Seriennummer",
-                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                    "description": "Seriennummer des Mähroboters. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
+                },
+                "mower_entity": {
+                    "name": "Entität",
+                    "description": "Wählen Sie die Mähroboter-Entität aus. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
                 },
                 "bump_sensitivity": {
                     "name": "Rasenbedingungen",
-                    "description": "Rasenbedingungen des Mähers"
+                    "description": "Die Rasenbedingungen des Mähroboters."
                 }
             }
         },
         "set_pin": {
-            "name": "PIN Code",
-            "description": "PIN Code des Mähers ändern",
+            "name": "PIN-Code ändern",
+            "description": "Ändert den PIN-Code des Mähroboters.",
             "fields": {
                 "mower_serial": {
                     "name": "Seriennummer",
-                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                    "description": "Seriennummer des Mähroboters. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
+                },
+                "mower_entity": {
+                    "name": "Entität",
+                    "description": "Wählen Sie die Mähroboter-Entität aus. Nur erforderlich, wenn mehrere Mähroboter konfiguriert sind."
                 },
                 "pin": {
-                    "name": "PIN Code",
-                    "description": "Neuer vierstelliger PIN Code des Mähers"
+                    "name": "PIN-Code",
+                    "description": "Neuer vierstelliger PIN-Code für den Mähroboter."
                 }
             }
         }
@@ -832,7 +872,7 @@
         "command_options": {
             "options": {
                 "mow": "Mähen",
-                "returnToDock": "Zurück zur Docking Station",
+                "returnToDock": "Zurück zur Ladestation",
                 "pause": "Pause"
             }
         },

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -171,7 +171,6 @@
             },
             "last_error_code": {
                 "name": "Last Error"
-                }
             },
             "firmware_version": {
                 "name": "Firmware Version"

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -152,7 +152,10 @@
                 "name": "Next Mow"
             },
             "mowing_mode": {
-                "name": "Mowing Mode"
+                "name": "Mowing Mode",
+                "state": {
+                    "Calendar": "Manual calendar"
+                }
             },
             "runtime_total": {
                 "name": "Mow Time Total"
@@ -167,7 +170,63 @@
                 "name": "Mower Position Y"
             },
             "last_error_code": {
-                "name": "Last Error"
+                "name": "Last Error",
+                "state": {
+                    "No error": "No error",
+                    "No errors": "No errors",
+                    "Unknown internal error": "Unknown internal error",
+                    "Button cell almost empty": "Button cell almost empty",
+                    "Compass error": "Compass error",
+                    "No data from mobile module": "No data from mobile module",
+                    "Mower tilted": "Mower tilted",
+                    "Mower was lifted": "Mower was lifted",
+                    "Lift sensor right front steering wheel": "Lift sensor right front steering wheel",
+                    "Lift sensor left front steering wheel": "Lift sensor left front steering wheel",
+                    "Stop button pressed": "Stop button pressed",
+                    "Mower tilted >45°": "Mower tilted >45°",
+                    "Invalid input": "Invalid input",
+                    "System error": "System error",
+                    "Permanent tactile detected": "Permanent tactile detected",
+                    "Charging current/voltage too high": "Charging current/voltage too high",
+                    "Cutter load too high": "Cutter load too high",
+                    "Internal error": "Internal error",
+                    "Left wheel blocked": "Left wheel blocked",
+                    "Right wheel blocked": "Right wheel blocked",
+                    "Internal wheel drive error": "Internal wheel drive error",
+                    "Intermittent error": "Intermittent error",
+                    "Mower out of perimeter limit": "Mower out of perimeter limit",
+                    "No signal from perimeter wire": "No signal from perimeter wire",
+                    "Waiting for loop signal": "Waiting for loop signal",
+                    "Charging error": "Charging error",
+                    "No perimeter signal detected": "No perimeter signal detected",
+                    "Left wheel stuck": "Left wheel stuck",
+                    "Mower stuck": "Mower stuck",
+                    "Mower trapped": "Mower trapped",
+                    "Mower too high": "Mower too high",
+                    "Unable to proceed": "Unable to proceed",
+                    "Uneven ground": "Uneven ground",
+                    "Grass too high": "Grass too high",
+                    "Bluetooth error": "Bluetooth error",
+                    "WiFi connection lost": "WiFi connection lost",
+                    "API connection error": "API connection error",
+                    "No connection to server": "No connection to server",
+                    "Communication timeout": "Communication timeout",
+                    "Firmware error": "Firmware error",
+                    "Software error": "Software error",
+                    "Configuration error": "Configuration error",
+                    "Memory error": "Memory error",
+                    "Unknown error": "Unknown error",
+                    "Shutdown detected": "Shutdown detected",
+                    "Inclination angle too large": "Inclination angle too large",
+                    "Last run error": "Last run error",
+                    "Orientation filter error": "Orientation filter error",
+                    "On-/Off error. Need PIN code to unlock": "On-/Off error. Need PIN code to unlock",
+                    "Unsupported battery pack": "Unsupported battery pack",
+                    "Reminder blade life": "Reminder blade life",
+                    "SmartMowing disabled": "SmartMowing disabled",
+                    "Software update complete": "Software update complete",
+                    "Mower reachable. SmartMow is now enabled.": "Mower reachable. SmartMow is now enabled."
+                }
             },
             "firmware_version": {
                 "name": "Firmware Version"
@@ -219,7 +278,7 @@
             "calendar_slots": {
                 "state": {
                     "smartmowing_active": "SmartMowing active",
-                    "calendar_selection_required": "Kalenderauswahl erforderlich",
+                    "calendar_selection_required": "Calendar selection required",
                     "off": "Off"
                 },
                 "name": "Planned mowing times",
@@ -587,77 +646,101 @@
     "services": {
         "command": {
             "name": "Send command",
-            "description": "Send commands to the mower. Allowed commands are mow, returnToDock, and pause.",
+            "description": "Sends a control command to the mower. Valid commands are \"mow\" (start mowing), \"returnToDock\" (return to charging station) and \"pause\" (pause mowing).",
             "fields": {
                 "mower_serial": {
-                    "name": "Mower Serial",
-                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                    "name": "Serial number",
+                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
+                },
+                "mower_entity": {
+                    "name": "Entity",
+                    "description": "Select the mower entity. Only required if multiple mowers are configured."
                 },
                 "command": {
                     "name": "Command",
-                    "description": "Select a command to send to the mower."
+                    "description": "Command to send to the mower."
                 }
             }
         },
         "smartmowing": {
             "name": "Toggle SmartMowing",
-            "description": "Enable or disable SmartMowing. Allowed values are true or false.",
+            "description": "Enables or disables the SmartMowing feature, which automatically adjusts the mowing schedule based on weather conditions and lawn growth.",
             "fields": {
                 "mower_serial": {
-                    "name": "Mower Serial",
-                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                    "name": "Serial number",
+                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
+                },
+                "mower_entity": {
+                    "name": "Entity",
+                    "description": "Select the mower entity. Only required if multiple mowers are configured."
                 },
                 "enable": {
-                    "name": "Enable",
-                    "description": "Enable SmartMowing."
+                    "name": "Activate/Deactivate",
+                    "description": "Sets the SmartMowing state. Use \"true\" to enable or \"false\" to disable the feature."
                 }
             }
         },
         "delete_alert": {
             "name": "Delete alert",
-            "description": "Delete the selected alert.",
+            "description": "Deletes a specific alert by its index. Index 0 refers to the most recent alert.",
             "fields": {
                 "mower_serial": {
-                    "name": "Mower Serial",
-                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                    "name": "Serial number",
+                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
+                },
+                "mower_entity": {
+                    "name": "Entity",
+                    "description": "Select the mower entity. Only required if multiple mowers are configured."
                 },
                 "alert_index": {
-                    "name": "Alert Index",
-                    "description": "Delete the selected alert. 0 for the latest alert."
+                    "name": "Alert index",
+                    "description": "Index of the alert to delete. 0 = most recent, 1 = second most recent, and so on."
                 }
             }
         },
         "delete_alert_all": {
             "name": "Delete all alerts",
-            "description": "Delete all alerts.",
+            "description": "Deletes all existing alerts for the mower at once.",
             "fields": {
                 "mower_serial": {
-                    "name": "Mower Serial",
-                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                    "name": "Serial number",
+                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
+                },
+                "mower_entity": {
+                    "name": "Entity",
+                    "description": "Select the mower entity. Only required if multiple mowers are configured."
                 }
             }
         },
         "read_alert": {
             "name": "Mark alert as read",
-            "description": "Mark the selected alert as read.",
+            "description": "Marks a specific alert as read by its index. Index 0 refers to the most recent alert.",
             "fields": {
                 "mower_serial": {
-                    "name": "Mower Serial",
-                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                    "name": "Serial number",
+                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
+                },
+                "mower_entity": {
+                    "name": "Entity",
+                    "description": "Select the mower entity. Only required if multiple mowers are configured."
                 },
                 "alert_index": {
-                    "name": "Alert Index",
-                    "description": "Mark the selected alert as read. 0 for the latest alert."
+                    "name": "Alert index",
+                    "description": "Index of the alert to mark as read. 0 = most recent, 1 = second most recent, and so on."
                 }
             }
         },
         "read_alert_all": {
             "name": "Mark all alerts as read",
-            "description": "Mark all alerts as read.",
+            "description": "Marks all existing alerts for the mower as read.",
             "fields": {
                 "mower_serial": {
-                    "name": "Mower Serial",
-                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                    "name": "Serial number",
+                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
+                },
+                "mower_entity": {
+                    "name": "Entity",
+                    "description": "Select the mower entity. Only required if multiple mowers are configured."
                 }
             }
         },
@@ -666,89 +749,104 @@
             "description": "Downloads the current mowing map from the Bosch Cloud API and saves it locally as \"www/indego_map_base.svg\". The map reflects the most recently recorded mowing route.",
             "fields": {
                 "mower_serial": {
-                    "name": "Mower Serial",
-                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                    "name": "Serial number",
+                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
+                },
+                "mower_entity": {
+                    "name": "Entity",
+                    "description": "Select the mower entity. Only required if multiple mowers are configured."
                 }
             }
         },
         "set_calendar_slot": {
-            "name": "Activate/Deactivate calendar slot",
-            "description": "Set a calender slot when you use the manual calendar instead of SmartMowing.",
+            "name": "Set calendar slot",
+            "description": "Set a calendar slot when you use a manual schedule instead of SmartMowing.",
             "fields": {
                 "mower_serial": {
-                    "name": "Serialnumber",
+                    "name": "Serial number",
                     "description": "Serial number of the mower. Only required if multiple mowers are configured."
                 },
-                "calendar_type": {
-                    "name": "Calendar Type",
-                    "description": "Type of calendar to use. Use 'calendar' for manual calendar or 'predictive' for the forbidden time slots in SmartMowing mode."
+                "mower_entity": {
+                    "name": "Entity",
+                    "description": "Select the mower entity. Only required if multiple mowers are configured."
                 },
                 "days": {
-                    "name": "Day",
-                    "description": "Which day to configure.",
-                    "example": "Montag"
+                    "name": "Days",
+                    "description": "Which day to configure."
                 },
                 "slot": {
-                    "name": "Time slot",
-                    "description": "Which Slot of the selected day should be configured (1 or 2)."
+                    "name": "Slot",
+                    "description": "Which slot of the selected day should be configured (1 or 2)."
                 },
                 "enabled": {
                     "name": "Activate/Deactivate",
                     "description": "Should the selected slot be enabled or disabled."
                 },
                 "start": {
-                    "name": "Start",
-                    "description": "Set Start Time of the selected slot and day. Only needed if you want to enable a slot."
+                    "name": "Start time",
+                    "description": "Set the start time of the selected slot and day. Only needed if you want to enable a slot. Only hour and minute will be used."
                 },
                 "end": {
-                    "name": "End",
-                    "description": "Set End Time of the selected slot and day. Only needed if you want to enable a slot."
-                }
-            }
-        },
-        "set_bump_sensitivity": {
-            "name": "Set mower lawn conditions",
-            "description": "Set the mower lawn conditions",
-            "fields": {
-                "mower_serial": {
-                    "name": "Serial number",
-                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
-                },
-                "bump_sensitivity": {
-                    "name": "Lawn conditions",
-                    "description": "Lawn conditions of the mower"
-                }
-            }
-        },
-        "set_pin": {
-            "name": "PIN Code",
-            "description": "Change the mower PIN code",
-            "fields": {
-                "mower_serial": {
-                    "name": "Serial number",
-                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
-                },
-                "pin": {
-                    "name": "PIN Code",
-                    "description": "New four-digit mower PIN code"
+                    "name": "End time",
+                    "description": "Set the end time of the selected slot and day. Only needed if you want to enable a slot. Only hour and minute will be used."
                 }
             }
         },
         "set_predictive_mowing_window": {
             "name": "Set SmartMowing mowing window",
-            "description": "Set the time window in which the mower may mow in SmartMowing mode.",
+            "description": "Set the allowed mowing window for SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Serial number",
                     "description": "Serial number of the mower. Only required if multiple mowers are configured."
                 },
+                "mower_entity": {
+                    "name": "Entity",
+                    "description": "Select the mower entity. Only required if multiple mowers are configured."
+                },
                 "earliest_start": {
                     "name": "Earliest start",
-                    "description": "The earliest time the mower should start."
+                    "description": "Earliest time SmartMowing is allowed to mow. Only hours and minutes are used."
                 },
                 "latest_end": {
                     "name": "Latest end",
-                    "description": "The latest time the mower should finish."
+                    "description": "Latest time SmartMowing is allowed to mow. Only hours and minutes are used."
+                }
+            }
+        },
+        "set_bump_sensitivity": {
+            "name": "Set lawn conditions",
+            "description": "Set the mower bump sensitivity.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serial number",
+                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
+                },
+                "mower_entity": {
+                    "name": "Entity",
+                    "description": "Select the mower entity. Only required if multiple mowers are configured."
+                },
+                "bump_sensitivity": {
+                    "name": "Lawn conditions",
+                    "description": "Bump sensitivity of the mower."
+                }
+            }
+        },
+        "set_pin": {
+            "name": "Change PIN code",
+            "description": "Change the mower PIN code.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serial number",
+                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
+                },
+                "mower_entity": {
+                    "name": "Entity",
+                    "description": "Select the mower entity. Only required if multiple mowers are configured."
+                },
+                "pin": {
+                    "name": "PIN code",
+                    "description": "New 4-digit mower PIN code."
                 }
             }
         }
@@ -774,7 +872,7 @@
         "command_options": {
             "options": {
                 "mow": "Mow",
-                "return_to_dock": "Return to dock",
+                "returnToDock": "Return to dock",
                 "pause": "Pause"
             }
         },

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Mowing Mode",
                 "state": {
-                    "Calendar": "Manual calendar"
+                    "calendar": "Manual calendar"
                 }
             },
             "runtime_total": {
@@ -170,62 +170,7 @@
                 "name": "Mower Position Y"
             },
             "last_error_code": {
-                "name": "Last Error",
-                "state": {
-                    "No error": "No error",
-                    "No errors": "No errors",
-                    "Unknown internal error": "Unknown internal error",
-                    "Button cell almost empty": "Button cell almost empty",
-                    "Compass error": "Compass error",
-                    "No data from mobile module": "No data from mobile module",
-                    "Mower tilted": "Mower tilted",
-                    "Mower was lifted": "Mower was lifted",
-                    "Lift sensor right front steering wheel": "Lift sensor right front steering wheel",
-                    "Lift sensor left front steering wheel": "Lift sensor left front steering wheel",
-                    "Stop button pressed": "Stop button pressed",
-                    "Mower tilted >45°": "Mower tilted >45°",
-                    "Invalid input": "Invalid input",
-                    "System error": "System error",
-                    "Permanent tactile detected": "Permanent tactile detected",
-                    "Charging current/voltage too high": "Charging current/voltage too high",
-                    "Cutter load too high": "Cutter load too high",
-                    "Internal error": "Internal error",
-                    "Left wheel blocked": "Left wheel blocked",
-                    "Right wheel blocked": "Right wheel blocked",
-                    "Internal wheel drive error": "Internal wheel drive error",
-                    "Intermittent error": "Intermittent error",
-                    "Mower out of perimeter limit": "Mower out of perimeter limit",
-                    "No signal from perimeter wire": "No signal from perimeter wire",
-                    "Waiting for loop signal": "Waiting for loop signal",
-                    "Charging error": "Charging error",
-                    "No perimeter signal detected": "No perimeter signal detected",
-                    "Left wheel stuck": "Left wheel stuck",
-                    "Mower stuck": "Mower stuck",
-                    "Mower trapped": "Mower trapped",
-                    "Mower too high": "Mower too high",
-                    "Unable to proceed": "Unable to proceed",
-                    "Uneven ground": "Uneven ground",
-                    "Grass too high": "Grass too high",
-                    "Bluetooth error": "Bluetooth error",
-                    "WiFi connection lost": "WiFi connection lost",
-                    "API connection error": "API connection error",
-                    "No connection to server": "No connection to server",
-                    "Communication timeout": "Communication timeout",
-                    "Firmware error": "Firmware error",
-                    "Software error": "Software error",
-                    "Configuration error": "Configuration error",
-                    "Memory error": "Memory error",
-                    "Unknown error": "Unknown error",
-                    "Shutdown detected": "Shutdown detected",
-                    "Inclination angle too large": "Inclination angle too large",
-                    "Last run error": "Last run error",
-                    "Orientation filter error": "Orientation filter error",
-                    "On-/Off error. Need PIN code to unlock": "On-/Off error. Need PIN code to unlock",
-                    "Unsupported battery pack": "Unsupported battery pack",
-                    "Reminder blade life": "Reminder blade life",
-                    "SmartMowing disabled": "SmartMowing disabled",
-                    "Software update complete": "Software update complete",
-                    "Mower reachable. SmartMow is now enabled.": "Mower reachable. SmartMow is now enabled."
+                "name": "Last Error"
                 }
             },
             "firmware_version": {
@@ -872,7 +817,7 @@
         "command_options": {
             "options": {
                 "mow": "Mow",
-                "returnToDock": "Return to dock",
+                "return_to_dock": "Return to dock",
                 "pause": "Pause"
             }
         },

--- a/custom_components/indego/translations/es.json
+++ b/custom_components/indego/translations/es.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Modo de corte",
                 "state": {
-                    "calendar": "Calendario manual"
+                    "Calendar": "Calendario manual"
                 }
             },
             "runtime_total": {
@@ -647,77 +647,101 @@
     "services": {
         "command": {
             "name": "Enviar comando",
-            "description": "Enviar comandos al cortacésped. Seleccione un comando.",
+            "description": "Envía un comando de control al cortacésped. Los comandos válidos son \"mow\" (iniciar corte), \"returnToDock\" (volver a la estación de carga) y \"pause\" (pausar el corte).",
             "fields": {
                 "mower_serial": {
-                    "description": "Número de serie del robot. Solo es necesario cuando tiene configurados varios robots cortacéspedes.",
-                    "name": "Número de serie"
+                    "name": "Número de serie",
+                    "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
+                "mower_entity": {
+                    "name": "Entidad",
+                    "description": "Seleccione la entidad del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
                 },
                 "command": {
-                    "name": "Enviar comando",
-                    "description": "Enviar comandos al cortacésped. Seleccione un comando."
+                    "name": "Comando",
+                    "description": "Comando a enviar al cortacésped."
                 }
             }
         },
         "smartmowing": {
             "name": "Alternar SmartMowing",
-            "description": "Habilitar o deshabilitar SmartMowing. Los valores permitidos son true o false.",
+            "description": "Activa o desactiva la función SmartMowing, que ajusta automáticamente el programa de corte según las condiciones meteorológicas y el crecimiento del césped.",
             "fields": {
                 "mower_serial": {
-                    "description": "Número de serie del robot. Solo es necesario cuando tiene configurados varios robots cortacéspedes.",
-                    "name": "Número de serie"
+                    "name": "Número de serie",
+                    "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
+                "mower_entity": {
+                    "name": "Entidad",
+                    "description": "Seleccione la entidad del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
                 },
                 "enable": {
-                    "description": "Habilitar SmartMowing.",
-                    "name": "Activar/desactivar"
+                    "name": "Activar/desactivar",
+                    "description": "Establece el estado de SmartMowing. Use \"true\" para activar o \"false\" para desactivar la función."
                 }
             }
         },
         "delete_alert": {
             "name": "Eliminar alerta",
-            "description": "Eliminar la alerta seleccionada.",
+            "description": "Elimina una alerta específica según su índice. El índice 0 se refiere a la alerta más reciente.",
             "fields": {
                 "mower_serial": {
-                    "description": "Número de serie del robot. Solo es necesario cuando tiene configurados varios robots cortacéspedes.",
-                    "name": "Número de serie"
+                    "name": "Número de serie",
+                    "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
+                "mower_entity": {
+                    "name": "Entidad",
+                    "description": "Seleccione la entidad del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
                 },
                 "alert_index": {
-                    "description": "Eliminar la alerta seleccionada. 0 para la alerta más reciente.",
-                    "name": "Índice de alerta"
+                    "name": "Índice de alerta",
+                    "description": "Índice de la alerta a eliminar. 0 = más reciente, 1 = segunda más reciente, etc."
                 }
             }
         },
         "delete_alert_all": {
             "name": "Eliminar todas las alertas",
-            "description": "Eliminar todas las alertas.",
+            "description": "Elimina todas las alertas existentes del cortacésped de una vez.",
             "fields": {
                 "mower_serial": {
-                    "description": "Número de serie del robot. Solo es necesario cuando tiene configurados varios robots cortacéspedes.",
-                    "name": "Número de serie"
+                    "name": "Número de serie",
+                    "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
+                "mower_entity": {
+                    "name": "Entidad",
+                    "description": "Seleccione la entidad del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
                 }
             }
         },
         "read_alert": {
             "name": "Marcar alerta como leída",
-            "description": "Marcar la alerta seleccionada como leída.",
+            "description": "Marca una alerta específica como leída según su índice. El índice 0 se refiere a la alerta más reciente.",
             "fields": {
                 "mower_serial": {
-                    "description": "Número de serie del robot. Solo es necesario cuando tiene configurados varios robots cortacéspedes.",
-                    "name": "Número de serie"
+                    "name": "Número de serie",
+                    "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
+                "mower_entity": {
+                    "name": "Entidad",
+                    "description": "Seleccione la entidad del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
                 },
                 "alert_index": {
-                    "description": "Marcar la alerta seleccionada como leída. 0 para la alerta más reciente.",
-                    "name": "Índice de alerta"
+                    "name": "Índice de alerta",
+                    "description": "Índice de la alerta a marcar como leída. 0 = más reciente, 1 = segunda más reciente, etc."
                 }
             }
         },
         "read_alert_all": {
             "name": "Marcar todas las alertas como leídas",
-            "description": "Marcar todas las alertas como leídas.",
+            "description": "Marca todas las alertas existentes del cortacésped como leídas.",
             "fields": {
                 "mower_serial": {
-                    "description": "Número de serie del robot. Solo es necesario cuando tiene configurados varios robots cortacéspedes.",
-                    "name": "Número de serie"
+                    "name": "Número de serie",
+                    "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
+                "mower_entity": {
+                    "name": "Entidad",
+                    "description": "Seleccione la entidad del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
                 }
             }
         },
@@ -726,88 +750,104 @@
             "description": "Descarga el mapa de corte actual desde la API de Bosch Cloud y lo guarda localmente como \"www/indego_map_base.svg\". El mapa refleja la ruta de corte más recientemente registrada.",
             "fields": {
                 "mower_serial": {
-                    "description": "Número de serie del robot. Solo es necesario cuando tiene configurados varios robots cortacéspedes.",
-                    "name": "Número de serie"
+                    "name": "Número de serie",
+                    "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
+                "mower_entity": {
+                    "name": "Entidad",
+                    "description": "Seleccione la entidad del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
                 }
             }
         },
         "set_calendar_slot": {
-            "name": "Activar/desactivar intervalo del calendario",
-            "description": "Modificar un intervalo del calendario (cambiar horarios, activar o desactivar)",
+            "name": "Configurar intervalo del calendario",
+            "description": "Configura un intervalo del calendario cuando se usa un horario manual en lugar de SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Número de serie",
                     "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
                 },
-                "calendar_type": {
-                    "name": "Tipo de calendario",
-                    "description": "Selecciona el calendario ('calendar' para el calendario manual o 'predictive' para los períodos desactivados en el modo SmartMowing)."
+                "mower_entity": {
+                    "name": "Entidad",
+                    "description": "Seleccione la entidad del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
                 },
                 "days": {
-                    "name": "Día",
-                    "description": "Nombre del día de la semana que se va a configurar."
+                    "name": "Días",
+                    "description": "Qué día de la semana configurar."
                 },
                 "slot": {
-                    "name": "Intervalo de tiempo",
-                    "description": "Qué intervalo de tiempo se debe modificar (1 o 2)."
+                    "name": "Intervalo",
+                    "description": "Qué intervalo del día seleccionado configurar (1 o 2)."
                 },
                 "enabled": {
                     "name": "Activar/desactivar",
-                    "description": "Activar o desactivar el día/intervalo seleccionado."
+                    "description": "Si el intervalo seleccionado debe estar activado o desactivado."
                 },
                 "start": {
-                    "name": "Inicio",
-                    "description": "Hora de inicio del intervalo seleccionado. Solo es necesaria si se va a activar un intervalo. Solo se utilizan horas y minutos."
+                    "name": "Hora de inicio",
+                    "description": "Hora de inicio del intervalo y día seleccionados. Solo es necesario si se desea activar un intervalo. Solo se utilizan horas y minutos."
                 },
                 "end": {
-                    "name": "Fin",
-                    "description": "Hora de finalización del intervalo seleccionado. Solo es necesaria si se va a activar un intervalo. Solo se utilizan horas y minutos."
-                }
-            }
-        },
-        "set_bump_sensitivity": {
-            "name": "Configurar las condiciones del césped del cortacésped",
-            "description": "Configurar las condiciones del césped del cortacésped",
-            "fields": {
-                "mower_serial": {
-                    "name": "Número de serie",
-                    "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
-                },
-                "bump_sensitivity": {
-                    "name": "Condiciones del césped",
-                    "description": "Condiciones del césped del cortacésped"
-                }
-            }
-        },
-        "set_pin": {
-            "name": "Código PIN",
-            "description": "Cambiar el código PIN del cortacésped",
-            "fields": {
-                "mower_serial": {
-                    "name": "Número de serie",
-                    "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
-                },
-                "pin": {
-                    "name": "Código PIN",
-                    "description": "Nuevo código PIN de cuatro dígitos del cortacésped"
+                    "name": "Hora de fin",
+                    "description": "Hora de fin del intervalo y día seleccionados. Solo es necesario si se desea activar un intervalo. Solo se utilizan horas y minutos."
                 }
             }
         },
         "set_predictive_mowing_window": {
             "name": "Establecer ventana horaria de SmartMowing",
-            "description": "La ventana horaria en la que el cortacésped puede cortar en modo SmartMowing.",
+            "description": "Establece la ventana de corte permitida para SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Número de serie",
                     "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
                 },
+                "mower_entity": {
+                    "name": "Entidad",
+                    "description": "Seleccione la entidad del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
                 "earliest_start": {
                     "name": "Inicio más temprano",
-                    "description": "La hora más temprana a la que debe empezar el cortacésped."
+                    "description": "Hora más temprana en la que SmartMowing puede cortar. Solo se utilizan horas y minutos."
                 },
                 "latest_end": {
                     "name": "Fin más tardío",
-                    "description": "La hora más tardía a la que debe terminar el cortacésped."
+                    "description": "Hora más tardía en la que SmartMowing puede cortar. Solo se utilizan horas y minutos."
+                }
+            }
+        },
+        "set_bump_sensitivity": {
+            "name": "Establecer condiciones del césped",
+            "description": "Establece la sensibilidad a impactos del cortacésped.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Número de serie",
+                    "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
+                "mower_entity": {
+                    "name": "Entidad",
+                    "description": "Seleccione la entidad del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
+                "bump_sensitivity": {
+                    "name": "Condiciones del césped",
+                    "description": "Sensibilidad a impactos del cortacésped."
+                }
+            }
+        },
+        "set_pin": {
+            "name": "Cambiar código PIN",
+            "description": "Cambia el código PIN del cortacésped.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Número de serie",
+                    "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
+                "mower_entity": {
+                    "name": "Entidad",
+                    "description": "Seleccione la entidad del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
+                "pin": {
+                    "name": "Código PIN",
+                    "description": "Nuevo código PIN de 4 dígitos para el cortacésped."
                 }
             }
         }

--- a/custom_components/indego/translations/es.json
+++ b/custom_components/indego/translations/es.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Modo de corte",
                 "state": {
-                    "Calendar": "Calendario manual"
+                    "calendar": "Calendario manual"
                 }
             },
             "runtime_total": {
@@ -873,7 +873,7 @@
         "command_options": {
             "options": {
                 "mow": "Cortar césped",
-                "returnToDock": "Volver a la estación de carga",
+                "return_to_dock": "Volver a la estación de carga",
                 "pause": "Pausa"
             }
         },

--- a/custom_components/indego/translations/fr.json
+++ b/custom_components/indego/translations/fr.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Mode de tonte",
                 "state": {
-                    "Calendar": "Calendrier manuel"
+                    "calendar": "Calendrier manuel"
                 }
             },
             "runtime_total": {
@@ -873,7 +873,7 @@
         "command_options": {
             "options": {
                 "mow": "Tondre",
-                "returnToDock": "Retour à la station de charge",
+                "return_to_dock": "Retour à la station de charge",
                 "pause": "Pause"
             }
         },

--- a/custom_components/indego/translations/fr.json
+++ b/custom_components/indego/translations/fr.json
@@ -102,10 +102,10 @@
             "mower_state_detail": {
                 "name": "Détails sur l'état de la tondeuse",
                 "state": {
-                    "Sleeping": "En veille",
                     "Reading status": "Obtention du statut en cours",
                     "Charging": "Charge en cours",
                     "Docked": "Dans station de charge",
+                    "Sleeping": "En veille",
                     "Docked - Software update": "Dans station de charge - Mise à jour du logiciel",
                     "Docked - Loading map": "Dans station de charge - Chargement carte",
                     "Docked - Saving map": "Dans station de charge - Enregistrement carte",
@@ -647,77 +647,101 @@
     "services": {
         "command": {
             "name": "Envoyer une commande",
-            "description": "Envoyer des commandes à la tondeuse. Sélectionnez une commande.",
+            "description": "Envoie une commande de contrôle à la tondeuse. Les commandes valides sont \"mow\" (démarrer la tonte), \"returnToDock\" (retour à la station de charge) et \"pause\" (mettre en pause la tonte).",
             "fields": {
                 "mower_serial": {
-                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si vous avez configuré plusieurs tondeuses.",
-                    "name": "Numéro de série"
+                    "name": "Numéro de série",
+                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
+                },
+                "mower_entity": {
+                    "name": "Entité",
+                    "description": "Sélectionnez l'entité de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
                 },
                 "command": {
-                    "name": "Envoyer une commande",
-                    "description": "Envoyer des commandes à la tondeuse. Sélectionnez une commande."
+                    "name": "Commande",
+                    "description": "Commande à envoyer à la tondeuse."
                 }
             }
         },
         "smartmowing": {
             "name": "Basculer SmartMowing",
-            "description": "Activer ou désactiver le SmartMowing. Les valeurs autorisées sont true (activé) ou false (désactivé).",
+            "description": "Active ou désactive la fonction SmartMowing, qui ajuste automatiquement le programme de tonte en fonction des conditions météorologiques et de la croissance de la pelouse.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si vous avez configuré plusieurs tondeuses.",
-                    "name": "Numéro de série"
+                    "name": "Numéro de série",
+                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
+                },
+                "mower_entity": {
+                    "name": "Entité",
+                    "description": "Sélectionnez l'entité de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
                 },
                 "enable": {
-                    "description": "Activer SmartMowing.",
-                    "name": "Activer/désactiver"
+                    "name": "Activer/désactiver",
+                    "description": "Définit l'état de SmartMowing. Utilisez \"true\" pour activer ou \"false\" pour désactiver la fonction."
                 }
             }
         },
         "delete_alert": {
             "name": "Supprimer l'alerte",
-            "description": "Effacer l'alerte sélectionnée.",
+            "description": "Supprime une alerte spécifique en fonction de son index. L'index 0 fait référence à l'alerte la plus récente.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si vous avez configuré plusieurs tondeuses.",
-                    "name": "Numéro de série"
+                    "name": "Numéro de série",
+                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
+                },
+                "mower_entity": {
+                    "name": "Entité",
+                    "description": "Sélectionnez l'entité de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
                 },
                 "alert_index": {
-                    "description": "Effacer l'alerte sélectionnée. 0 pour la dernière alerte.",
-                    "name": "Index de l'alerte"
+                    "name": "Index de l'alerte",
+                    "description": "Index de l'alerte à supprimer. 0 = plus récente, 1 = deuxième plus récente, etc."
                 }
             }
         },
         "delete_alert_all": {
             "name": "Supprimer toutes les alertes",
-            "description": "Effacer toutes les alertes.",
+            "description": "Supprime toutes les alertes existantes de la tondeuse d'un seul coup.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si vous avez configuré plusieurs tondeuses.",
-                    "name": "Numéro de série"
+                    "name": "Numéro de série",
+                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
+                },
+                "mower_entity": {
+                    "name": "Entité",
+                    "description": "Sélectionnez l'entité de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
                 }
             }
         },
         "read_alert": {
             "name": "Marquer l'alerte comme lue",
-            "description": "Marquer l'alerte sélectionnée comme lue.",
+            "description": "Marque une alerte spécifique comme lue en fonction de son index. L'index 0 fait référence à l'alerte la plus récente.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si vous avez configuré plusieurs tondeuses.",
-                    "name": "Numéro de série"
+                    "name": "Numéro de série",
+                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
+                },
+                "mower_entity": {
+                    "name": "Entité",
+                    "description": "Sélectionnez l'entité de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
                 },
                 "alert_index": {
-                    "description": "Marquer l'alerte sélectionnée comme lue. 0 pour la dernière alerte.",
-                    "name": "Index de l'alerte"
+                    "name": "Index de l'alerte",
+                    "description": "Index de l'alerte à marquer comme lue. 0 = plus récente, 1 = deuxième plus récente, etc."
                 }
             }
         },
         "read_alert_all": {
             "name": "Marquer toutes les alertes comme lues",
-            "description": "Marquer toutes les alertes comme lues.",
+            "description": "Marque toutes les alertes existantes de la tondeuse comme lues.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si vous avez configuré plusieurs tondeuses.",
-                    "name": "Numéro de série"
+                    "name": "Numéro de série",
+                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
+                },
+                "mower_entity": {
+                    "name": "Entité",
+                    "description": "Sélectionnez l'entité de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
                 }
             }
         },
@@ -726,88 +750,104 @@
             "description": "Télécharge la carte de tonte actuelle depuis l'API Bosch Cloud et l'enregistre localement sous \"www/indego_map_base.svg\". La carte reflète l'itinéraire de tonte le plus récemment enregistré.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si vous avez configuré plusieurs tondeuses.",
-                    "name": "Numéro de série"
+                    "name": "Numéro de série",
+                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
+                },
+                "mower_entity": {
+                    "name": "Entité",
+                    "description": "Sélectionnez l'entité de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
                 }
             }
         },
         "set_calendar_slot": {
-            "name": "Activer/désactiver un créneau du calendrier",
-            "description": "Modifier un créneau du calendrier (changer les horaires, activer ou désactiver)",
+            "name": "Configurer un créneau du calendrier",
+            "description": "Configure un créneau du calendrier lorsque vous utilisez un programme manuel au lieu de SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Numéro de série",
-                    "description": "Numéro de série de la tondeuse. Nécessaire uniquement si plusieurs tondeuses sont configurées."
+                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
                 },
-                "calendar_type": {
-                    "name": "Type de calendrier",
-                    "description": "Sélectionnez le calendrier ('calendar' pour le calendrier manuel ou 'predictive' pour les périodes désactivées en mode SmartMowing)."
+                "mower_entity": {
+                    "name": "Entité",
+                    "description": "Sélectionnez l'entité de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
                 },
                 "days": {
-                    "name": "Jour",
-                    "description": "Nom du jour de la semaine à configurer."
+                    "name": "Jours",
+                    "description": "Quel jour de la semaine configurer."
                 },
                 "slot": {
-                    "name": "Créneau horaire",
-                    "description": "Créneau à modifier (1 ou 2)."
+                    "name": "Créneau",
+                    "description": "Quel créneau du jour sélectionné configurer (1 ou 2)."
                 },
                 "enabled": {
                     "name": "Activer/désactiver",
-                    "description": "Activer ou désactiver le jour/créneau sélectionné."
+                    "description": "Indique si le créneau sélectionné doit être activé ou désactivé."
                 },
                 "start": {
-                    "name": "Début",
-                    "description": "Heure de début du créneau sélectionné. Requise uniquement lorsqu’un créneau doit être activé. Seules les heures et les minutes sont utilisées."
+                    "name": "Heure de début",
+                    "description": "Heure de début du créneau et du jour sélectionnés. Uniquement nécessaire si vous souhaitez activer un créneau. Seules les heures et les minutes sont utilisées."
                 },
                 "end": {
-                    "name": "Fin",
-                    "description": "Heure de fin du créneau sélectionné. Requise uniquement lorsqu’un créneau doit être activé. Seules les heures et les minutes sont utilisées."
-                }
-            }
-        },
-        "set_bump_sensitivity": {
-            "name": "Définir les conditions de la pelouse de la tondeuse",
-            "description": "Définir les conditions de la pelouse de la tondeuse",
-            "fields": {
-                "mower_serial": {
-                    "name": "Numéro de série",
-                    "description": "Numéro de série de la tondeuse. Requis uniquement si plusieurs tondeuses sont configurées."
-                },
-                "bump_sensitivity": {
-                    "name": "Conditions de la pelouse",
-                    "description": "Conditions de la pelouse de la tondeuse"
-                }
-            }
-        },
-        "set_pin": {
-            "name": "Code PIN",
-            "description": "Modifier le code PIN de la tondeuse",
-            "fields": {
-                "mower_serial": {
-                    "name": "Numéro de série",
-                    "description": "Numéro de série de la tondeuse. Requis uniquement si plusieurs tondeuses sont configurées."
-                },
-                "pin": {
-                    "name": "Code PIN",
-                    "description": "Nouveau code PIN à quatre chiffres de la tondeuse"
+                    "name": "Heure de fin",
+                    "description": "Heure de fin du créneau et du jour sélectionnés. Uniquement nécessaire si vous souhaitez activer un créneau. Seules les heures et les minutes sont utilisées."
                 }
             }
         },
         "set_predictive_mowing_window": {
-            "name": "Définir la fenêtre SmartMowing",
-            "description": "La fenêtre horaire pendant laquelle la tondeuse peut tondre en mode SmartMowing.",
+            "name": "Définir la fenêtre horaire SmartMowing",
+            "description": "Définit la fenêtre de tonte autorisée pour SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Numéro de série",
-                    "description": "Numéro de série de la tondeuse. Requis uniquement si plusieurs tondeuses sont configurées."
+                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
+                },
+                "mower_entity": {
+                    "name": "Entité",
+                    "description": "Sélectionnez l'entité de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
                 },
                 "earliest_start": {
                     "name": "Début le plus tôt",
-                    "description": "L'heure la plus tôt à laquelle la tondeuse doit commencer."
+                    "description": "Heure la plus précoce à laquelle SmartMowing est autorisé à tondre. Seules les heures et les minutes sont utilisées."
                 },
                 "latest_end": {
                     "name": "Fin au plus tard",
-                    "description": "L'heure la plus tardive à laquelle la tondeuse doit terminer."
+                    "description": "Heure la plus tardive à laquelle SmartMowing est autorisé à tondre. Seules les heures et les minutes sont utilisées."
+                }
+            }
+        },
+        "set_bump_sensitivity": {
+            "name": "Définir les conditions de la pelouse",
+            "description": "Définit la sensibilité aux chocs de la tondeuse.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Numéro de série",
+                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
+                },
+                "mower_entity": {
+                    "name": "Entité",
+                    "description": "Sélectionnez l'entité de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
+                },
+                "bump_sensitivity": {
+                    "name": "Conditions de la pelouse",
+                    "description": "Sensibilité aux chocs de la tondeuse."
+                }
+            }
+        },
+        "set_pin": {
+            "name": "Modifier le code PIN",
+            "description": "Modifie le code PIN de la tondeuse.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Numéro de série",
+                    "description": "Numéro de série de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
+                },
+                "mower_entity": {
+                    "name": "Entité",
+                    "description": "Sélectionnez l'entité de la tondeuse. Uniquement nécessaire si plusieurs tondeuses sont configurées."
+                },
+                "pin": {
+                    "name": "Code PIN",
+                    "description": "Nouveau code PIN à 4 chiffres pour la tondeuse."
                 }
             }
         }

--- a/custom_components/indego/translations/it.json
+++ b/custom_components/indego/translations/it.json
@@ -647,167 +647,207 @@
     "services": {
         "command": {
             "name": "Invia comando",
-            "description": "Invia comandi al robot. Seleziona un comando.",
+            "description": "Invia un comando di controllo al rasaerba. I comandi validi sono \"mow\" (avvia il taglio), \"returnToDock\" (ritorna alla stazione di ricarica) e \"pause\" (metti in pausa il taglio).",
             "fields": {
                 "mower_serial": {
-                    "description": "Numero di serie del rasaerba. Necessario solo quando hai configurato più rasaerba.",
-                    "name": "Numero di serie"
+                    "name": "Numero di serie",
+                    "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
+                "mower_entity": {
+                    "name": "Entità",
+                    "description": "Seleziona l'entità del rasaerba. Necessario solo se sono configurati più rasaerba."
                 },
                 "command": {
-                    "name": "Invia comando",
-                    "description": "Invia comandi al robot. Seleziona un comando."
+                    "name": "Comando",
+                    "description": "Comando da inviare al rasaerba."
                 }
             }
         },
         "smartmowing": {
             "name": "Attiva/Disattiva SmartMowing",
-            "description": "Abilita o disabilita SmartMowing. I valori consentiti sono true o false.",
+            "description": "Attiva o disattiva la funzione SmartMowing, che regola automaticamente il programma di taglio in base alle condizioni meteorologiche e alla crescita dell'erba.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numero di serie del rasaerba. Necessario solo quando hai configurato più rasaerba.",
-                    "name": "Numero di serie"
+                    "name": "Numero di serie",
+                    "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
+                "mower_entity": {
+                    "name": "Entità",
+                    "description": "Seleziona l'entità del rasaerba. Necessario solo se sono configurati più rasaerba."
                 },
                 "enable": {
-                    "description": "Abilita SmartMowing.",
-                    "name": "Attiva/disattiva"
+                    "name": "Attiva/disattiva",
+                    "description": "Imposta lo stato di SmartMowing. Usa \"true\" per attivare o \"false\" per disattivare la funzione."
                 }
             }
         },
         "delete_alert": {
             "name": "Elimina avviso",
-            "description": "Elimina l'avviso selezionato.",
+            "description": "Elimina un avviso specifico in base al suo indice. L'indice 0 si riferisce all'avviso più recente.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numero di serie del rasaerba. Necessario solo quando hai configurato più rasaerba.",
-                    "name": "Numero di serie"
+                    "name": "Numero di serie",
+                    "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
+                "mower_entity": {
+                    "name": "Entità",
+                    "description": "Seleziona l'entità del rasaerba. Necessario solo se sono configurati più rasaerba."
                 },
                 "alert_index": {
-                    "description": "Elimina l'avviso selezionato. 0 per l'avviso più recente.",
-                    "name": "Indice avviso"
+                    "name": "Indice avviso",
+                    "description": "Indice dell'avviso da eliminare. 0 = più recente, 1 = secondo più recente, ecc."
                 }
             }
         },
         "delete_alert_all": {
             "name": "Elimina tutti gli avvisi",
-            "description": "Elimina tutti gli avvisi.",
+            "description": "Elimina tutti gli avvisi esistenti del rasaerba in una volta sola.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numero di serie del rasaerba. Necessario solo quando hai configurato più rasaerba.",
-                    "name": "Numero di serie"
+                    "name": "Numero di serie",
+                    "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
+                "mower_entity": {
+                    "name": "Entità",
+                    "description": "Seleziona l'entità del rasaerba. Necessario solo se sono configurati più rasaerba."
                 }
             }
         },
         "read_alert": {
             "name": "Segna avviso come letto",
-            "description": "Segna l'avviso selezionato come letto.",
+            "description": "Segna un avviso specifico come letto in base al suo indice. L'indice 0 si riferisce all'avviso più recente.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numero di serie del rasaerba. Necessario solo quando hai configurato più rasaerba.",
-                    "name": "Numero di serie"
+                    "name": "Numero di serie",
+                    "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
+                "mower_entity": {
+                    "name": "Entità",
+                    "description": "Seleziona l'entità del rasaerba. Necessario solo se sono configurati più rasaerba."
                 },
                 "alert_index": {
-                    "description": "Segna l'avviso selezionato come letto. 0 per l'avviso più recente.",
-                    "name": "Indice avviso"
+                    "name": "Indice avviso",
+                    "description": "Indice dell'avviso da segnare come letto. 0 = più recente, 1 = secondo più recente, ecc."
                 }
             }
         },
         "read_alert_all": {
             "name": "Segna tutti gli avvisi come letti",
-            "description": "Segna tutti gli avvisi come letti.",
+            "description": "Segna tutti gli avvisi esistenti del rasaerba come letti.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numero di serie del rasaerba. Necessario solo quando hai configurato più rasaerba.",
-                    "name": "Numero di serie"
+                    "name": "Numero di serie",
+                    "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
+                "mower_entity": {
+                    "name": "Entità",
+                    "description": "Seleziona l'entità del rasaerba. Necessario solo se sono configurati più rasaerba."
                 }
             }
         },
         "download_map": {
-            "name": "Scarica mappa falciatura",
-            "description": "Scarica la mappa di taglio attuale dall'API Bosch Cloud e la salva localmente come \"www/indego_map_base.svg\". La mappa riflette il percorso di taglio registrato più di recente.",
+            "name": "Scarica mappa di taglio",
+            "description": "Scarica la mappa di taglio corrente dall'API Bosch Cloud e la salva localmente come \"www/indego_map_base.svg\". La mappa riflette il percorso di taglio registrato più di recente.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numero di serie del rasaerba. Necessario solo quando hai configurato più rasaerba.",
-                    "name": "Numero di serie"
+                    "name": "Numero di serie",
+                    "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
+                "mower_entity": {
+                    "name": "Entità",
+                    "description": "Seleziona l'entità del rasaerba. Necessario solo se sono configurati più rasaerba."
                 }
             }
         },
         "set_calendar_slot": {
-            "name": "Attiva/disattiva slot del calendario",
-            "description": "Modifica uno slot del calendario (cambia orari, attiva o disattiva)",
+            "name": "Configura slot del calendario",
+            "description": "Configura uno slot del calendario quando si utilizza un programma manuale invece di SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Numero di serie",
                     "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
                 },
-                "calendar_type": {
-                    "name": "Tipo di calendario",
-                    "description": "Seleziona il calendario ('calendar' per il calendario manuale o 'predictive' per i periodi disattivati in modalità SmartMowing)."
+                "mower_entity": {
+                    "name": "Entità",
+                    "description": "Seleziona l'entità del rasaerba. Necessario solo se sono configurati più rasaerba."
                 },
                 "days": {
-                    "name": "Giorno",
-                    "description": "Nome del giorno della settimana da configurare."
+                    "name": "Giorni",
+                    "description": "Quale giorno della settimana configurare."
                 },
                 "slot": {
-                    "name": "Fascia oraria",
-                    "description": "Quale fascia oraria deve essere modificata (1 o 2)."
+                    "name": "Slot",
+                    "description": "Quale slot del giorno selezionato configurare (1 o 2)."
                 },
                 "enabled": {
                     "name": "Attiva/disattiva",
-                    "description": "Attiva o disattiva il giorno/la fascia oraria selezionata."
+                    "description": "Indica se lo slot selezionato deve essere attivato o disattivato."
                 },
                 "start": {
-                    "name": "Inizio",
-                    "description": "Ora di inizio della fascia selezionata. Necessaria solo se la fascia deve essere attivata. Vengono utilizzate solo ore e minuti."
+                    "name": "Ora di inizio",
+                    "description": "Ora di inizio dello slot e del giorno selezionati. Necessaria solo se si desidera attivare uno slot. Vengono utilizzate solo ore e minuti."
                 },
                 "end": {
-                    "name": "Fine",
-                    "description": "Ora di fine della fascia selezionata. Necessaria solo se la fascia deve essere attivata. Vengono utilizzate solo ore e minuti."
-                }
-            }
-        },
-        "set_bump_sensitivity": {
-            "name": "Imposta le condizioni del prato del tosaerba",
-            "description": "Imposta le condizioni del prato del tosaerba",
-            "fields": {
-                "mower_serial": {
-                    "name": "Numero di serie",
-                    "description": "Numero di serie del tosaerba. Richiesto solo se sono configurati più tosaerba."
-                },
-                "bump_sensitivity": {
-                    "name": "Condizioni del prato",
-                    "description": "Condizioni del prato del tosaerba"
-                }
-            }
-        },
-        "set_pin": {
-            "name": "Codice PIN",
-            "description": "Modifica il codice PIN del rasaerba",
-            "fields": {
-                "mower_serial": {
-                    "name": "Numero di serie",
-                    "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
-                },
-                "pin": {
-                    "name": "Codice PIN",
-                    "description": "Nuovo codice PIN a quattro cifre del rasaerba"
+                    "name": "Ora di fine",
+                    "description": "Ora di fine dello slot e del giorno selezionati. Necessaria solo se si desidera attivare uno slot. Vengono utilizzate solo ore e minuti."
                 }
             }
         },
         "set_predictive_mowing_window": {
             "name": "Imposta finestra oraria SmartMowing",
-            "description": "La finestra oraria in cui il rasaerba può tagliare in modalità SmartMowing.",
+            "description": "Imposta la finestra di taglio consentita per SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Numero di serie",
                     "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
                 },
+                "mower_entity": {
+                    "name": "Entità",
+                    "description": "Seleziona l'entità del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
                 "earliest_start": {
                     "name": "Inizio più anticipato",
-                    "description": "L'orario più anticipato in cui il rasaerba deve iniziare."
+                    "description": "Ora più precoce in cui SmartMowing può tagliare. Vengono utilizzate solo ore e minuti."
                 },
                 "latest_end": {
                     "name": "Fine più tardiva",
-                    "description": "L'orario più tardivo in cui il rasaerba deve terminare."
+                    "description": "Ora più tardiva in cui SmartMowing può tagliare. Vengono utilizzate solo ore e minuti."
+                }
+            }
+        },
+        "set_bump_sensitivity": {
+            "name": "Imposta condizioni del prato",
+            "description": "Imposta la sensibilità agli urti del rasaerba.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Numero di serie",
+                    "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
+                "mower_entity": {
+                    "name": "Entità",
+                    "description": "Seleziona l'entità del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
+                "bump_sensitivity": {
+                    "name": "Condizioni del prato",
+                    "description": "Sensibilità agli urti del rasaerba."
+                }
+            }
+        },
+        "set_pin": {
+            "name": "Cambia codice PIN",
+            "description": "Cambia il codice PIN del rasaerba.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Numero di serie",
+                    "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
+                "mower_entity": {
+                    "name": "Entità",
+                    "description": "Seleziona l'entità del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
+                "pin": {
+                    "name": "Codice PIN",
+                    "description": "Nuovo codice PIN a 4 cifre per il rasaerba."
                 }
             }
         }

--- a/custom_components/indego/translations/it.json
+++ b/custom_components/indego/translations/it.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Modalità di taglio",
                 "state": {
-                    "Calendar": "Calendario manuale"
+                    "calendar": "Calendario manuale"
                 }
             },
             "runtime_total": {
@@ -873,7 +873,7 @@
         "command_options": {
             "options": {
                 "mow": "Taglia l'erba",
-                "returnToDock": "Ritorna alla stazione di ricarica",
+                "return_to_dock": "Ritorna alla stazione di ricarica",
                 "pause": "Pausa"
             }
         },

--- a/custom_components/indego/translations/nl.json
+++ b/custom_components/indego/translations/nl.json
@@ -647,167 +647,207 @@
     "services": {
         "command": {
             "name": "Stuur commando",
-            "description": "Stuur commando's naar de grasmaaier. Selecteer een commando.",
-            "fields": {
-                "mower_serial": {
-                    "description": "Grasmaaier serienummer. Alleen nodig wanneer je meerdere grasmaaiers hebt geconfigureerd.",
-                    "name": "Serienummer"
-                },
-                "command": {
-                    "name": "Stuur commando",
-                    "description": "Stuur commando's naar de grasmaaier. Selecteer een commando."
-                }
-            }
-        },
-        "smartmowing": {
-            "name": "SmartMowing inschakelen",
-            "description": "Schakel SmartMowing in of uit. Ondersteunde waardes zijn: true of false.",
-            "fields": {
-                "mower_serial": {
-                    "description": "Grasmaaier serienummer. Alleen nodig wanneer je meerdere grasmaaiers hebt geconfigureerd.",
-                    "name": "Serienummer"
-                },
-                "enable": {
-                    "description": "Schakel SmartMowing in of uit.",
-                    "name": "Inschakelen/uitschakelen"
-                }
-            }
-        },
-        "delete_alert": {
-            "name": "Waarschuwing verwijderen",
-            "description": "Verwijder een specifieke melding.",
-            "fields": {
-                "mower_serial": {
-                    "description": "Grasmaaier serienummer. Alleen nodig wanneer je meerdere grasmaaiers hebt geconfigureerd.",
-                    "name": "Serienummer"
-                },
-                "alert_index": {
-                    "description": "De index van de melding. 0 is het nieuwste bericht.",
-                    "name": "Meldingsindex"
-                }
-            }
-        },
-        "delete_alert_all": {
-            "name": "Alle waarschuwingen verwijderen",
-            "description": "Verwijder alle meldingen.",
-            "fields": {
-                "mower_serial": {
-                    "description": "Grasmaaier serienummer. Alleen nodig wanneer je meerdere grasmaaiers hebt geconfigureerd.",
-                    "name": "Serienummer"
-                }
-            }
-        },
-        "read_alert": {
-            "name": "Waarschuwing als gelezen markeren",
-            "description": "Markeer een specifieke melding als gelezen.",
-            "fields": {
-                "mower_serial": {
-                    "description": "Grasmaaier serienummer. Alleen nodig wanneer je meerdere grasmaaiers hebt geconfigureerd.",
-                    "name": "Serienummer"
-                },
-                "alert_index": {
-                    "description": "De index van de melding. 0 is het nieuwste bericht.",
-                    "name": "Meldingsindex"
-                }
-            }
-        },
-        "read_alert_all": {
-            "name": "Alle waarschuwingen als gelezen markeren",
-            "description": "Markeer alle meldingen als gelezen.",
-            "fields": {
-                "mower_serial": {
-                    "description": "Grasmaaier serienummer. Alleen nodig wanneer je meerdere grasmaaiers hebt geconfigureerd.",
-                    "name": "Serienummer"
-                }
-            }
-        },
-        "download_map": {
-            "name": "Maaiwerkkaart downloaden",
-            "description": "Downloaded de huidge maaikaart van de Bosch Cloud API en slaat deze lokaal op als \"www/indego_map_base.svg\". De kaart weerspiegelt de laatst opgenomen maairoute.",
-            "fields": {
-                "mower_serial": {
-                    "description": "Grasmaaier serienummer. Alleen nodig wanneer je meerdere grasmaaiers hebt geconfigureerd.",
-                    "name": "Serienummer"
-                }
-            }
-        },
-        "set_calendar_slot": {
-            "name": "Kalenderslot activeren/deactiveren",
-            "description": "Wijzig een kalenderslot (tijden wijzigen, activeren of deactiveren)",
-            "fields": {
-                "mower_serial": {
-                    "name": "Serienummer",
-                    "description": "Serienummer van de grasmaaier. Alleen nodig als er meerdere grasmaaiers zijn geconfigureerd."
-                },
-                "calendar_type": {
-                    "name": "Kalendertype",
-                    "description": "Selecteer de kalender ('calendar' voor de handmatige kalender of 'predictive' voor gedeactiveerde tijden in SmartMowing-modus)."
-                },
-                "days": {
-                    "name": "Dag",
-                    "description": "Naam van de weekdag die moet worden geconfigureerd."
-                },
-                "slot": {
-                    "name": "Tijdslot",
-                    "description": "Welk tijdslot moet worden gewijzigd (1 of 2)."
-                },
-                "enabled": {
-                    "name": "Activeren/deactiveren",
-                    "description": "Activeer of deactiveer de geselecteerde dag/het geselecteerde tijdslot."
-                },
-                "start": {
-                    "name": "Start",
-                    "description": "Starttijd van het geselecteerde tijdslot. Alleen nodig als het tijdslot geactiveerd moet worden. Alleen uren en minuten worden gebruikt."
-                },
-                "end": {
-                    "name": "Einde",
-                    "description": "Eindtijd van het geselecteerde tijdslot. Alleen nodig als het tijdslot geactiveerd moet worden. Alleen uren en minuten worden gebruikt."
-                }
-            }
-        },
-        "set_bump_sensitivity": {
-            "name": "Gazonomstandigheden van de maaier instellen",
-            "description": "De gazonomstandigheden van de maaier instellen",
+            "description": "Stuurt een besturingscommando naar de maaier. Geldige commando's zijn \"mow\" (maaien starten), \"returnToDock\" (terug naar oplaadstation) en \"pause\" (maaien pauzeren).",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
                     "description": "Serienummer van de maaier. Alleen vereist als meerdere maaiers zijn geconfigureerd."
                 },
-                "bump_sensitivity": {
-                    "name": "Gazonomstandigheden",
-                    "description": "Gazonomstandigheden van de maaier"
+                "mower_entity": {
+                    "name": "Entiteit",
+                    "description": "Selecteer de maaier-entiteit. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "command": {
+                    "name": "Commando",
+                    "description": "Commando dat naar de maaier moet worden verzonden."
                 }
             }
         },
-        "set_pin": {
-            "name": "PIN-code",
-            "description": "PIN-code van de maaier wijzigen",
+        "smartmowing": {
+            "name": "SmartMowing inschakelen",
+            "description": "In- of uitschakelen van de SmartMowing-functie, die het maaischema automatisch aanpast op basis van weersomstandigheden en grasgroei.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Serienummer van de maaier. Alleen nodig als meerdere maaiers zijn geconfigureerd."
+                    "description": "Serienummer van de maaier. Alleen vereist als meerdere maaiers zijn geconfigureerd."
                 },
-                "pin": {
-                    "name": "PIN-code",
-                    "description": "Nieuwe viercijferige PIN-code van de maaier"
+                "mower_entity": {
+                    "name": "Entiteit",
+                    "description": "Selecteer de maaier-entiteit. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "enable": {
+                    "name": "Inschakelen/uitschakelen",
+                    "description": "Stelt de SmartMowing-status in. Gebruik \"true\" om in te schakelen of \"false\" om uit te schakelen."
+                }
+            }
+        },
+        "delete_alert": {
+            "name": "Waarschuwing verwijderen",
+            "description": "Verwijdert een specifieke waarschuwing op basis van de index. Index 0 verwijst naar de meest recente waarschuwing.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummer van de maaier. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "mower_entity": {
+                    "name": "Entiteit",
+                    "description": "Selecteer de maaier-entiteit. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "alert_index": {
+                    "name": "Waarschuwingsindex",
+                    "description": "Index van de te verwijderen waarschuwing. 0 = meest recente, 1 = op één na meest recente, enz."
+                }
+            }
+        },
+        "delete_alert_all": {
+            "name": "Alle waarschuwingen verwijderen",
+            "description": "Verwijdert alle bestaande waarschuwingen van de maaier in één keer.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummer van de maaier. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "mower_entity": {
+                    "name": "Entiteit",
+                    "description": "Selecteer de maaier-entiteit. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                }
+            }
+        },
+        "read_alert": {
+            "name": "Waarschuwing als gelezen markeren",
+            "description": "Markeert een specifieke waarschuwing als gelezen op basis van de index. Index 0 verwijst naar de meest recente waarschuwing.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummer van de maaier. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "mower_entity": {
+                    "name": "Entiteit",
+                    "description": "Selecteer de maaier-entiteit. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "alert_index": {
+                    "name": "Waarschuwingsindex",
+                    "description": "Index van de als gelezen te markeren waarschuwing. 0 = meest recente, 1 = op één na meest recente, enz."
+                }
+            }
+        },
+        "read_alert_all": {
+            "name": "Alle waarschuwingen als gelezen markeren",
+            "description": "Markeert alle bestaande waarschuwingen van de maaier als gelezen.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummer van de maaier. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "mower_entity": {
+                    "name": "Entiteit",
+                    "description": "Selecteer de maaier-entiteit. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                }
+            }
+        },
+        "download_map": {
+            "name": "Maaiwerkkaart downloaden",
+            "description": "Downloadt de huidige maaikaart van de Bosch Cloud API en slaat deze lokaal op als \"www/indego_map_base.svg\". De kaart weerspiegelt de laatst opgenomen maairoute.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummer van de maaier. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "mower_entity": {
+                    "name": "Entiteit",
+                    "description": "Selecteer de maaier-entiteit. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                }
+            }
+        },
+        "set_calendar_slot": {
+            "name": "Kalenderslot instellen",
+            "description": "Stelt een kalenderslot in wanneer u een handmatig schema gebruikt in plaats van SmartMowing.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummer van de maaier. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "mower_entity": {
+                    "name": "Entiteit",
+                    "description": "Selecteer de maaier-entiteit. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "days": {
+                    "name": "Dagen",
+                    "description": "Welke dag van de week moet worden geconfigureerd."
+                },
+                "slot": {
+                    "name": "Slot",
+                    "description": "Welk slot van de geselecteerde dag moet worden geconfigureerd (1 of 2)."
+                },
+                "enabled": {
+                    "name": "Inschakelen/uitschakelen",
+                    "description": "Of het geselecteerde slot moet worden ingeschakeld of uitgeschakeld."
+                },
+                "start": {
+                    "name": "Starttijd",
+                    "description": "Stel de starttijd in voor het geselecteerde slot en de dag. Alleen nodig als u een slot wilt inschakelen. Alleen uren en minuten worden gebruikt."
+                },
+                "end": {
+                    "name": "Eindtijd",
+                    "description": "Stel de eindtijd in voor het geselecteerde slot en de dag. Alleen nodig als u een slot wilt inschakelen. Alleen uren en minuten worden gebruikt."
                 }
             }
         },
         "set_predictive_mowing_window": {
             "name": "SmartMowing-tijdvenster instellen",
-            "description": "Het tijdvenster waarin de maaier in SmartMowing-modus mag maaien.",
+            "description": "Stelt het toegestane maaivenster in voor SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Serienummer van de maaier. Alleen nodig als meerdere maaiers zijn geconfigureerd."
+                    "description": "Serienummer van de maaier. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "mower_entity": {
+                    "name": "Entiteit",
+                    "description": "Selecteer de maaier-entiteit. Alleen vereist als meerdere maaiers zijn geconfigureerd."
                 },
                 "earliest_start": {
                     "name": "Vroegste start",
-                    "description": "De vroegste tijd waarop de maaier moet beginnen."
+                    "description": "Vroegste tijd waarop SmartMowing mag maaien. Alleen uren en minuten worden gebruikt."
                 },
                 "latest_end": {
                     "name": "Laatste einde",
-                    "description": "De laatste tijd waarop de maaier moet stoppen."
+                    "description": "Laatste tijd waarop SmartMowing mag maaien. Alleen uren en minuten worden gebruikt."
+                }
+            }
+        },
+        "set_bump_sensitivity": {
+            "name": "Gazonomstandigheden instellen",
+            "description": "Stelt de stootgevoeligheid van de maaier in.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummer van de maaier. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "mower_entity": {
+                    "name": "Entiteit",
+                    "description": "Selecteer de maaier-entiteit. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "bump_sensitivity": {
+                    "name": "Gazonomstandigheden",
+                    "description": "Stootgevoeligheid van de maaier."
+                }
+            }
+        },
+        "set_pin": {
+            "name": "PIN-code wijzigen",
+            "description": "Wijzigt de PIN-code van de maaier.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummer van de maaier. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "mower_entity": {
+                    "name": "Entiteit",
+                    "description": "Selecteer de maaier-entiteit. Alleen vereist als meerdere maaiers zijn geconfigureerd."
+                },
+                "pin": {
+                    "name": "PIN-code",
+                    "description": "Nieuwe 4-cijferige PIN-code voor de maaier."
                 }
             }
         }

--- a/custom_components/indego/translations/nl.json
+++ b/custom_components/indego/translations/nl.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Maaimode",
                 "state": {
-                    "Calendar": "Handmatige kalender"
+                    "calendar": "Handmatige kalender"
                 }
             },
             "runtime_total": {
@@ -873,7 +873,7 @@
         "command_options": {
             "options": {
                 "mow": "Maaien",
-                "returnToDock": "Terug naar het laadstation",
+                "return_to_dock": "Terug naar het laadstation",
                 "pause": "Pauze"
             }
         },

--- a/custom_components/indego/translations/no.json
+++ b/custom_components/indego/translations/no.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Klippemodus",
                 "state": {
-                    "Calendar": "Manuell kalender"
+                    "calendar": "Manuell kalender"
                 }
             },
             "runtime_total": {
@@ -873,7 +873,7 @@
         "command_options": {
             "options": {
                 "mow": "Klipp gress",
-                "returnToDock": "Tilbake til ladestasjonen",
+                "return_to_dock": "Tilbake til ladestasjonen",
                 "pause": "Pause"
             }
         },

--- a/custom_components/indego/translations/no.json
+++ b/custom_components/indego/translations/no.json
@@ -647,167 +647,207 @@
     "services": {
         "command": {
             "name": "Send kommando",
-            "description": "Send kommandoer til gressklipperen. Velg en kommando.",
+            "description": "Sender en styringskommando til gressklipperen. Gyldige kommandoer er \"mow\" (start klipping), \"returnToDock\" (retur til ladestasjon) og \"pause\" (pause klipping).",
             "fields": {
                 "mower_serial": {
-                    "description": "Gressklipperens serienummer. Bare nødvendig hvis du har konfigurert flere gressklippere.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Serienummeret til gressklipperen. Bare nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Velg gressklipper-entiteten. Bare nødvendig hvis flere gressklippere er konfigurert."
                 },
                 "command": {
-                    "name": "Send kommando",
-                    "description": "Send kommandoer til gressklipperen. Velg en kommando."
+                    "name": "Kommando",
+                    "description": "Kommando som skal sendes til gressklipperen."
                 }
             }
         },
         "smartmowing": {
             "name": "Slå SmartMowing på/av",
-            "description": "Aktiver eller deaktiver SmartMowing. Tillatte verdier er true eller false.",
+            "description": "Aktiverer eller deaktiverer SmartMowing-funksjonen, som automatisk justerer klippeplanen basert på værforhold og gressvekst.",
             "fields": {
                 "mower_serial": {
-                    "description": "Gressklipperens serienummer. Bare nødvendig hvis du har konfigurert flere gressklippere.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Serienummeret til gressklipperen. Bare nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Velg gressklipper-entiteten. Bare nødvendig hvis flere gressklippere er konfigurert."
                 },
                 "enable": {
-                    "description": "Aktiver SmartMowing.",
-                    "name": "Aktiver/deaktiver"
+                    "name": "Aktiver/deaktiver",
+                    "description": "Setter SmartMowing-statusen. Bruk \"true\" for å aktivere eller \"false\" for å deaktivere funksjonen."
                 }
             }
         },
         "delete_alert": {
             "name": "Slett varsel",
-            "description": "Slett den valgte advarselen.",
+            "description": "Sletter en bestemt advarsel basert på indeksen. Indeks 0 refererer til den nyeste advarselen.",
             "fields": {
                 "mower_serial": {
-                    "description": "Gressklipperens serienummer. Bare nødvendig hvis du har konfigurert flere gressklippere.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Serienummeret til gressklipperen. Bare nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Velg gressklipper-entiteten. Bare nødvendig hvis flere gressklippere er konfigurert."
                 },
                 "alert_index": {
-                    "description": "Slett den valgte advarselen. 0 for den siste advarselen.",
-                    "name": "Varselindeks"
+                    "name": "Varselindeks",
+                    "description": "Indeks for advarselen som skal slettes. 0 = nyeste, 1 = nest nyeste, osv."
                 }
             }
         },
         "delete_alert_all": {
             "name": "Slett alle varsler",
-            "description": "Slett alle advarsler.",
+            "description": "Sletter alle eksisterende advarsler for gressklipperen på en gang.",
             "fields": {
                 "mower_serial": {
-                    "description": "Gressklipperens serienummer. Bare nødvendig hvis du har konfigurert flere gressklippere.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Serienummeret til gressklipperen. Bare nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Velg gressklipper-entiteten. Bare nødvendig hvis flere gressklippere er konfigurert."
                 }
             }
         },
         "read_alert": {
             "name": "Merk varsel som lest",
-            "description": "Merk den valgte advarselen som lest.",
+            "description": "Merk en bestemt advarsel som lest basert på indeksen. Indeks 0 refererer til den nyeste advarselen.",
             "fields": {
                 "mower_serial": {
-                    "description": "Gressklipperens serienummer. Bare nødvendig hvis du har konfigurert flere gressklippere.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Serienummeret til gressklipperen. Bare nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Velg gressklipper-entiteten. Bare nødvendig hvis flere gressklippere er konfigurert."
                 },
                 "alert_index": {
-                    "description": "Merk den valgte advarselen som lest. 0 for den siste advarselen.",
-                    "name": "Varselindeks"
+                    "name": "Varselindeks",
+                    "description": "Indeks for advarselen som skal merkes som lest. 0 = nyeste, 1 = nest nyeste, osv."
                 }
             }
         },
         "read_alert_all": {
             "name": "Merk alle varsler som lest",
-            "description": "Merk alle advarsler som leste.",
+            "description": "Merker alle eksisterende advarsler for gressklipperen som lest.",
             "fields": {
                 "mower_serial": {
-                    "description": "Gressklipperens serienummer. Bare nødvendig hvis du har konfigurert flere gressklippere.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Serienummeret til gressklipperen. Bare nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Velg gressklipper-entiteten. Bare nødvendig hvis flere gressklippere er konfigurert."
                 }
             }
         },
         "download_map": {
             "name": "Last ned klippekart",
-            "description": "Henter det aktuelle klippkartet fra Bosch Cloud API og lagrer det lokalt som \"www/indego_map_base.svg\". Kartet gjenspeiler den senest registrerte klippingen rute.",
+            "description": "Henter det aktuelle klippekartet fra Bosch Cloud API og lagrer det lokalt som \"www/indego_map_base.svg\". Kartet gjenspeiler den senest registrerte klipperuten.",
             "fields": {
                 "mower_serial": {
-                    "description": "Gressklipperens serienummer. Bare nødvendig hvis du har konfigurert flere gressklippere.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Serienummeret til gressklipperen. Bare nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Velg gressklipper-entiteten. Bare nødvendig hvis flere gressklippere er konfigurert."
                 }
             }
         },
         "set_calendar_slot": {
-            "name": "Aktiver/deaktiver kalenderspor",
-            "description": "Endre et kalenderspor (endre tider, aktiver eller deaktiver)",
+            "name": "Angi kalenderspor",
+            "description": "Angir et kalenderspor når du bruker en manuell tidsplan i stedet for SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Serienummeret til gressklipperen. Kun nødvendig hvis flere gressklippere er konfigurert."
+                    "description": "Serienummeret til gressklipperen. Bare nødvendig hvis flere gressklippere er konfigurert."
                 },
-                "calendar_type": {
-                    "name": "Kalendertype",
-                    "description": "Velg kalender ('calendar' for manuell kalender eller 'predictive' for deaktiverte tidsrom i SmartMowing-modus)."
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Velg gressklipper-entiteten. Bare nødvendig hvis flere gressklippere er konfigurert."
                 },
                 "days": {
-                    "name": "Dag",
-                    "description": "Navnet på ukedagen som skal konfigureres."
+                    "name": "Dager",
+                    "description": "Hvilken dag som skal konfigureres."
                 },
                 "slot": {
                     "name": "Tidsrom",
-                    "description": "Hvilket tidsrom som skal endres (1 eller 2)."
+                    "description": "Hvilket tidsrom for den valgte dagen som skal konfigureres (1 eller 2)."
                 },
                 "enabled": {
                     "name": "Aktiver/deaktiver",
-                    "description": "Aktiver eller deaktiver valgt dag/tidsrom."
+                    "description": "Om det valgte tidsrommet skal aktiveres eller deaktiveres."
                 },
                 "start": {
-                    "name": "Start",
-                    "description": "Starttid for valgt tidsrom. Kun nødvendig hvis tidsrommet skal aktiveres. Kun timer og minutter brukes."
+                    "name": "Starttid",
+                    "description": "Angi starttid for valgt tidsrom og dag. Bare nødvendig hvis du vil aktivere et tidsrom. Bare time og minutt brukes."
                 },
                 "end": {
-                    "name": "Slutt",
-                    "description": "Sluttid for valgt tidsrom. Kun nødvendig hvis tidsrommet skal aktiveres. Kun timer og minutter brukes."
-                }
-            }
-        },
-        "set_bump_sensitivity": {
-            "name": "Angi plenforhold for klipperen",
-            "description": "Angi plenforholdene for klipperen",
-            "fields": {
-                "mower_serial": {
-                    "name": "Serienummer",
-                    "description": "Serienummer på klipperen. Kun nødvendig dersom flere klippere er konfigurert."
-                },
-                "bump_sensitivity": {
-                    "name": "Plenforhold",
-                    "description": "Plenforhold for klipperen"
-                }
-            }
-        },
-        "set_pin": {
-            "name": "PIN-kode",
-            "description": "Endre PIN-koden til klipperen",
-            "fields": {
-                "mower_serial": {
-                    "name": "Serienummer",
-                    "description": "Serienummer til klipperen. Kreves kun dersom flere klippere er konfigurert."
-                },
-                "pin": {
-                    "name": "PIN-kode",
-                    "description": "Ny firesifret PIN-kode for klipperen"
+                    "name": "Sluttid",
+                    "description": "Angi sluttid for valgt tidsrom og dag. Bare nødvendig hvis du vil aktivere et tidsrom. Bare time og minutt brukes."
                 }
             }
         },
         "set_predictive_mowing_window": {
             "name": "Angi SmartMowing-tidsvindu",
-            "description": "Tidsvinduet der klipperen kan klippe i SmartMowing-modus.",
+            "description": "Angir det tillatte klippevinduet for SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
-                    "description": "Serienummeret til klipperen. Kreves bare hvis flere klippere er konfigurert."
+                    "description": "Serienummeret til gressklipperen. Bare nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Velg gressklipper-entiteten. Bare nødvendig hvis flere gressklippere er konfigurert."
                 },
                 "earliest_start": {
                     "name": "Tidligste start",
-                    "description": "Det tidligste tidspunktet klipperen skal starte."
+                    "description": "Tidligste tidspunkt SmartMowing har lov til å klippe. Bare timer og minutter brukes."
                 },
                 "latest_end": {
                     "name": "Seneste slutt",
-                    "description": "Det seneste tidspunktet klipperen skal avslutte."
+                    "description": "Seneste tidspunkt SmartMowing har lov til å klippe. Bare timer og minutter brukes."
+                }
+            }
+        },
+        "set_bump_sensitivity": {
+            "name": "Angi plenforhold",
+            "description": "Setter klipperens støtfølsomhet.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummeret til gressklipperen. Bare nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Velg gressklipper-entiteten. Bare nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "bump_sensitivity": {
+                    "name": "Plenforhold",
+                    "description": "Klipperens støtfølsomhet."
+                }
+            }
+        },
+        "set_pin": {
+            "name": "Endre PIN-kode",
+            "description": "Endrer klipperens PIN-kode.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummeret til gressklipperen. Bare nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Velg gressklipper-entiteten. Bare nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "pin": {
+                    "name": "PIN-kode",
+                    "description": "Ny 4-sifret PIN-kode for klipperen."
                 }
             }
         }

--- a/custom_components/indego/translations/pl.json
+++ b/custom_components/indego/translations/pl.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Tryb koszenia",
                 "state": {
-                    "Calendar": "Kalendarz ręczny"
+                    "calendar": "Kalendarz ręczny"
                 }
             },
             "runtime_total": {
@@ -873,7 +873,7 @@
         "command_options": {
             "options": {
                 "mow": "Koszenie",
-                "returnToDock": "Powrót do stacji dokującej",
+                "return_to_dock": "Powrót do stacji dokującej",
                 "pause": "Pauza"
             }
         },

--- a/custom_components/indego/translations/pl.json
+++ b/custom_components/indego/translations/pl.json
@@ -647,167 +647,207 @@
     "services": {
         "command": {
             "name": "Wyślij polecenie",
-            "description": "Wyślij polecenia do kosiarki. Wybierz polecenie.",
+            "description": "Wysyła polecenie sterujące do kosiarki. Dozwolone polecenia to \"mow\" (rozpocznij koszenie), \"returnToDock\" (powrót do stacji ładowania) i \"pause\" (wstrzymaj koszenie).",
             "fields": {
                 "mower_serial": {
-                    "description": "Numer seryjny kosiarki. Wymagany tylko gdy konfigurujesz wiele kosiarek.",
-                    "name": "Numer seryjny"
+                    "name": "Numer seryjny",
+                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano wiele kosiarek."
+                },
+                "mower_entity": {
+                    "name": "Encja",
+                    "description": "Wybierz encję kosiarki. Wymagane tylko wtedy, gdy skonfigurowano wiele kosiarek."
                 },
                 "command": {
-                    "name": "Wyślij polecenie",
-                    "description": "Wyślij polecenia do kosiarki. Wybierz polecenie."
+                    "name": "Polecenie",
+                    "description": "Polecenie do wysłania do kosiarki."
                 }
             }
         },
         "smartmowing": {
             "name": "Przełącz SmartMowing",
-            "description": "Włącz lub wyłącz tryb SmartMowing. Dostępne wartości to true lub false.",
+            "description": "Włącza lub wyłącza funkcję SmartMowing, która automatycznie dostosowuje harmonogram koszenia na podstawie warunków pogodowych i wzrostu trawy.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numer seryjny kosiarki. Wymagany tylko gdy konfigurujesz wiele kosiarek.",
-                    "name": "Numer seryjny"
+                    "name": "Numer seryjny",
+                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano wiele kosiarek."
+                },
+                "mower_entity": {
+                    "name": "Encja",
+                    "description": "Wybierz encję kosiarki. Wymagane tylko wtedy, gdy skonfigurowano wiele kosiarek."
                 },
                 "enable": {
-                    "description": "Włącz tryb SmartMowing.",
-                    "name": "Włącz/wyłącz"
+                    "name": "Włącz/wyłącz",
+                    "description": "Ustawia stan SmartMowing. Użyj \"true\", aby włączyć, lub \"false\", aby wyłączyć funkcję."
                 }
             }
         },
         "delete_alert": {
             "name": "Usuń alert",
-            "description": "Usuń zaznaczony alert.",
+            "description": "Usuwa konkretny alert na podstawie jego indeksu. Indeks 0 oznacza najnowszy alert.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numer seryjny kosiarki. Wymagany tylko gdy konfigurujesz wiele kosiarek.",
-                    "name": "Numer seryjny"
+                    "name": "Numer seryjny",
+                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano wiele kosiarek."
+                },
+                "mower_entity": {
+                    "name": "Encja",
+                    "description": "Wybierz encję kosiarki. Wymagane tylko wtedy, gdy skonfigurowano wiele kosiarek."
                 },
                 "alert_index": {
-                    "description": "Usuń zaznaczony alert. 0 dla ostatniego alertu.",
-                    "name": "Indeks alertu"
+                    "name": "Indeks alertu",
+                    "description": "Indeks alertu do usunięcia. 0 = najnowszy, 1 = drugi najnowszy, itd."
                 }
             }
         },
         "delete_alert_all": {
             "name": "Usuń wszystkie alerty",
-            "description": "Usuń wszystkie alerty.",
+            "description": "Usuwa wszystkie istniejące alerty dla kosiarki za jednym razem.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numer seryjny kosiarki. Wymagany tylko gdy konfigurujesz wiele kosiarek.",
-                    "name": "Numer seryjny"
+                    "name": "Numer seryjny",
+                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano wiele kosiarek."
+                },
+                "mower_entity": {
+                    "name": "Encja",
+                    "description": "Wybierz encję kosiarki. Wymagane tylko wtedy, gdy skonfigurowano wiele kosiarek."
                 }
             }
         },
         "read_alert": {
             "name": "Oznacz alert jako przeczytany",
-            "description": "Oznacz alert jako przeczytany.",
+            "description": "Oznacza konkretny alert jako przeczytany na podstawie jego indeksu. Indeks 0 oznacza najnowszy alert.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numer seryjny kosiarki. Wymagany tylko gdy konfigurujesz wiele kosiarek.",
-                    "name": "Numer seryjny"
+                    "name": "Numer seryjny",
+                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano wiele kosiarek."
+                },
+                "mower_entity": {
+                    "name": "Encja",
+                    "description": "Wybierz encję kosiarki. Wymagane tylko wtedy, gdy skonfigurowano wiele kosiarek."
                 },
                 "alert_index": {
-                    "description": "Oznacz wybrany alert jako przeczytany. 0 dla ostatniego alertu.",
-                    "name": "Indeks alertu"
+                    "name": "Indeks alertu",
+                    "description": "Indeks alertu do oznaczenia jako przeczytany. 0 = najnowszy, 1 = drugi najnowszy, itd."
                 }
             }
         },
         "read_alert_all": {
             "name": "Oznacz wszystkie alerty jako przeczytane",
-            "description": "Oznacz wszystkie alerty jako przeczytane.",
+            "description": "Oznacza wszystkie istniejące alerty dla kosiarki jako przeczytane.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numer seryjny kosiarki. Wymagany tylko gdy konfigurujesz wiele kosiarek.",
-                    "name": "Numer seryjny"
+                    "name": "Numer seryjny",
+                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano wiele kosiarek."
+                },
+                "mower_entity": {
+                    "name": "Encja",
+                    "description": "Wybierz encję kosiarki. Wymagane tylko wtedy, gdy skonfigurowano wiele kosiarek."
                 }
             }
         },
         "download_map": {
             "name": "Pobierz mapę koszenia",
-            "description": "Pobiera aktualną mapę koszenia z API Bosch Cloud i zapisuje ją lokalnie jako \"www/indego_map_base.svg\". Mapa odzwierciedla ostatnio zapisaną trasę koszenia.",
+            "description": "Pobiera aktualną mapę koszenia z API Bosch Cloud i zapisuje ją lokalnie jako \"www/indego_map_base.svg\". Mapa odzwierciedla ostatnio zarejestrowaną trasę koszenia.",
             "fields": {
                 "mower_serial": {
-                    "description": "Numer seryjny kosiarki. Wymagany tylko gdy konfigurujesz wiele kosiarek.",
-                    "name": "Numer seryjny"
+                    "name": "Numer seryjny",
+                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano wiele kosiarek."
+                },
+                "mower_entity": {
+                    "name": "Encja",
+                    "description": "Wybierz encję kosiarki. Wymagane tylko wtedy, gdy skonfigurowano wiele kosiarek."
                 }
             }
         },
         "set_calendar_slot": {
-            "name": "Aktywuj/dezaktywuj przedział kalendarza",
-            "description": "Zmień przedział kalendarza (zmień godziny, aktywuj lub dezaktywuj)",
+            "name": "Ustaw slot kalendarza",
+            "description": "Ustawia slot kalendarza, gdy używasz ręcznego harmonogramu zamiast SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Numer seryjny",
-                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano kilka kosiarek."
+                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano wiele kosiarek."
                 },
-                "calendar_type": {
-                    "name": "Typ kalendarza",
-                    "description": "Wybierz kalendarz ('calendar' dla kalendarza ręcznego lub 'predictive' dla dezaktywowanych okresów w trybie SmartMowing)."
+                "mower_entity": {
+                    "name": "Encja",
+                    "description": "Wybierz encję kosiarki. Wymagane tylko wtedy, gdy skonfigurowano wiele kosiarek."
                 },
                 "days": {
-                    "name": "Dzień",
-                    "description": "Nazwa dnia tygodnia, który ma zostać skonfigurowany."
+                    "name": "Dni",
+                    "description": "Który dzień tygodnia skonfigurować."
                 },
                 "slot": {
-                    "name": "Przedział czasowy",
-                    "description": "Który przedział czasowy ma zostać zmieniony (1 lub 2)."
+                    "name": "Slot",
+                    "description": "Który slot wybranego dnia skonfigurować (1 lub 2)."
                 },
                 "enabled": {
-                    "name": "Aktywuj/dezaktywuj",
-                    "description": "Aktywuj lub dezaktywuj wybrany dzień/przedział czasowy."
+                    "name": "Włącz/wyłącz",
+                    "description": "Czy wybrany slot ma być włączony czy wyłączony."
                 },
                 "start": {
-                    "name": "Start",
-                    "description": "Godzina rozpoczęcia wybranego przedziału. Wymagana tylko wtedy, gdy przedział ma zostać aktywowany. Używane są tylko godziny i minuty."
+                    "name": "Godzina rozpoczęcia",
+                    "description": "Ustaw godzinę rozpoczęcia dla wybranego slotu i dnia. Wymagane tylko wtedy, gdy chcesz włączyć slot. Używane są tylko godziny i minuty."
                 },
                 "end": {
-                    "name": "Koniec",
-                    "description": "Godzina zakończenia wybranego przedziału. Wymagana tylko wtedy, gdy przedział ma zostać aktywowany. Używane są tylko godziny i minuty."
-                }
-            }
-        },
-        "set_bump_sensitivity": {
-            "name": "Ustaw warunki trawnika kosiarki",
-            "description": "Ustaw warunki trawnika kosiarki",
-            "fields": {
-                "mower_serial": {
-                    "name": "Numer seryjny",
-                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano więcej niż jedną kosiarkę."
-                },
-                "bump_sensitivity": {
-                    "name": "Warunki trawnika",
-                    "description": "Warunki trawnika kosiarki"
-                }
-            }
-        },
-        "set_pin": {
-            "name": "Kod PIN",
-            "description": "Zmień kod PIN kosiarki",
-            "fields": {
-                "mower_serial": {
-                    "name": "Numer seryjny",
-                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano więcej niż jedną kosiarkę."
-                },
-                "pin": {
-                    "name": "Kod PIN",
-                    "description": "Nowy czterocyfrowy kod PIN kosiarki"
+                    "name": "Godzina zakończenia",
+                    "description": "Ustaw godzinę zakończenia dla wybranego slotu i dnia. Wymagane tylko wtedy, gdy chcesz włączyć slot. Używane są tylko godziny i minuty."
                 }
             }
         },
         "set_predictive_mowing_window": {
             "name": "Ustaw okno czasowe SmartMowing",
-            "description": "Okno czasowe, w którym kosiarka może kosić w trybie SmartMowing.",
+            "description": "Ustawia dozwolone okno koszenia dla SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Numer seryjny",
-                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano więcej niż jedną kosiarkę."
+                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano wiele kosiarek."
+                },
+                "mower_entity": {
+                    "name": "Encja",
+                    "description": "Wybierz encję kosiarki. Wymagane tylko wtedy, gdy skonfigurowano wiele kosiarek."
                 },
                 "earliest_start": {
                     "name": "Najwcześniejszy start",
-                    "description": "Najwcześniejsza godzina rozpoczęcia pracy kosiarki."
+                    "description": "Najwcześniejszy czas, w którym SmartMowing może kosić. Używane są tylko godziny i minuty."
                 },
                 "latest_end": {
-                    "name": "Najpóźniejszy koniec",
-                    "description": "Najpóźniejsza godzina zakończenia pracy kosiarki."
+                    "name": "Najpóźniejsze zakończenie",
+                    "description": "Najpóźniejszy czas, w którym SmartMowing może kosić. Używane są tylko godziny i minuty."
+                }
+            }
+        },
+        "set_bump_sensitivity": {
+            "name": "Ustaw warunki trawnika",
+            "description": "Ustawia czułość na wstrząsy kosiarki.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Numer seryjny",
+                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano wiele kosiarek."
+                },
+                "mower_entity": {
+                    "name": "Encja",
+                    "description": "Wybierz encję kosiarki. Wymagane tylko wtedy, gdy skonfigurowano wiele kosiarek."
+                },
+                "bump_sensitivity": {
+                    "name": "Warunki trawnika",
+                    "description": "Czułość na wstrząsy kosiarki."
+                }
+            }
+        },
+        "set_pin": {
+            "name": "Zmień kod PIN",
+            "description": "Zmienia kod PIN kosiarki.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Numer seryjny",
+                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano wiele kosiarek."
+                },
+                "mower_entity": {
+                    "name": "Encja",
+                    "description": "Wybierz encję kosiarki. Wymagane tylko wtedy, gdy skonfigurowano wiele kosiarek."
+                },
+                "pin": {
+                    "name": "Kod PIN",
+                    "description": "Nowy 4-cyfrowy kod PIN dla kosiarki."
                 }
             }
         }

--- a/custom_components/indego/translations/sk.json
+++ b/custom_components/indego/translations/sk.json
@@ -124,7 +124,7 @@
                     "Loading map": "Načítavanie mapy",
                     "Learning lawn": "Učenie sa záhrady",
                     "Paused": "Pozastavené",
-                    "Border cut": "Косenie okrajov",
+                    "Border cut": "Кosenie okrajov",
                     "Idle in lawn": "Nečinnosť na trávniku",
                     "Stuck on lawn, help needed": "Uviaznuté na trávniku, potrebná pomoc",
                     "Returning to dock": "Návrat do stanice",
@@ -647,167 +647,207 @@
     "services": {
         "command": {
             "name": "Poslať príkaz",
-            "description": "Poslať príkazy kosačke. Vyberte príkaz.",
+            "description": "Odošle riadiaci príkaz kosačke. Platné príkazy sú \"mow\" (spustiť kosenie), \"returnToDock\" (návrat do nabíjacej stanice) a \"pause\" (pozastaviť kosenie).",
             "fields": {
                 "mower_serial": {
-                    "description": "Sériové číslo kosačky. Potrebné iba vtedy, keď máte nakonfigurovaných viacero kosačiek.",
-                    "name": "Sériové číslo"
+                    "name": "Sériové číslo",
+                    "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
+                "mower_entity": {
+                    "name": "Entita",
+                    "description": "Vyberte entitu kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
                 },
                 "command": {
-                    "name": "Poslať príkaz",
-                    "description": "Poslať príkazy kosačke. Vyberte príkaz."
+                    "name": "Príkaz",
+                    "description": "Príkaz, ktorý sa má odoslať kosačke."
                 }
             }
         },
         "smartmowing": {
             "name": "Prepnúť SmartMowing",
-            "description": "Povoliť alebo zakázať funkciu SmartMowing. Povolené hodnoty sú true alebo false.",
+            "description": "Zapína alebo vypína funkciu SmartMowing, ktorá automaticky upravuje plán kosenia na základe poveternostných podmienok a rastu trávy.",
             "fields": {
                 "mower_serial": {
-                    "description": "Sériové číslo kosačky. Potrebné iba vtedy, keď máte nakonfigurovaných viacero kosačiek.",
-                    "name": "Sériové číslo"
+                    "name": "Sériové číslo",
+                    "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
+                "mower_entity": {
+                    "name": "Entita",
+                    "description": "Vyberte entitu kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
                 },
                 "enable": {
-                    "description": "Povoliť SmartMowing.",
-                    "name": "Aktivovať/deaktivovať"
+                    "name": "Aktivovať/deaktivovať",
+                    "description": "Nastaví stav SmartMowing. Použite \"true\" na aktiváciu alebo \"false\" na deaktiváciu funkcie."
                 }
             }
         },
         "delete_alert": {
             "name": "Odstrániť výstrahu",
-            "description": "Odstrániť vybraté upozornenie.",
+            "description": "Odstráni konkrétne upozornenie na základe jeho indexu. Index 0 označuje najnovšie upozornenie.",
             "fields": {
                 "mower_serial": {
-                    "description": "Sériové číslo kosačky. Potrebné iba vtedy, keď máte nakonfigurovaných viacero kosačiek.",
-                    "name": "Sériové číslo"
+                    "name": "Sériové číslo",
+                    "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
+                "mower_entity": {
+                    "name": "Entita",
+                    "description": "Vyberte entitu kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
                 },
                 "alert_index": {
-                    "description": "Odstrániť vybraté upozornenie. 0 pre najnovšie upozornenie.",
-                    "name": "Index upozornenia"
+                    "name": "Index upozornenia",
+                    "description": "Index upozornenia, ktoré sa má odstrániť. 0 = najnovšie, 1 = druhé najnovšie, atď."
                 }
             }
         },
         "delete_alert_all": {
             "name": "Odstrániť všetky výstrahy",
-            "description": "Odstráňte všetky upozornenia.",
+            "description": "Odstráni všetky existujúce upozornenia kosačky naraz.",
             "fields": {
                 "mower_serial": {
-                    "description": "Sériové číslo kosačky. Potrebné iba vtedy, keď máte nakonfigurovaných viacero kosačiek.",
-                    "name": "Sériové číslo"
+                    "name": "Sériové číslo",
+                    "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
+                "mower_entity": {
+                    "name": "Entita",
+                    "description": "Vyberte entitu kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
                 }
             }
         },
         "read_alert": {
             "name": "Označiť výstrahu ako prečítanú",
-            "description": "Označte vybrané upozornenie ako prečítané.",
+            "description": "Označí konkrétne upozornenie ako prečítané na základe jeho indexu. Index 0 označuje najnovšie upozornenie.",
             "fields": {
                 "mower_serial": {
-                    "description": "Sériové číslo kosačky. Potrebné iba vtedy, keď máte nakonfigurovaných viacero kosačiek.",
-                    "name": "Sériové číslo"
+                    "name": "Sériové číslo",
+                    "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
+                "mower_entity": {
+                    "name": "Entita",
+                    "description": "Vyberte entitu kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
                 },
                 "alert_index": {
-                    "description": "Označte vybrané upozornenie ako prečítané. 0 pre najnovšie upozornenie.",
-                    "name": "Index upozornenia"
+                    "name": "Index upozornenia",
+                    "description": "Index upozornenia, ktoré sa má označiť ako prečítané. 0 = najnovšie, 1 = druhé najnovšie, atď."
                 }
             }
         },
         "read_alert_all": {
             "name": "Označiť všetky výstrahy ako prečítané",
-            "description": "Označte všetky upozornenia ako prečítané.",
+            "description": "Označí všetky existujúce upozornenia kosačky ako prečítané.",
             "fields": {
                 "mower_serial": {
-                    "description": "Sériové číslo kosačky. Potrebné iba vtedy, keď máte nakonfigurovaných viacero kosačiek.",
-                    "name": "Sériové číslo"
+                    "name": "Sériové číslo",
+                    "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
+                "mower_entity": {
+                    "name": "Entita",
+                    "description": "Vyberte entitu kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
                 }
             }
         },
         "download_map": {
             "name": "Stiahnuť mapu kosenia",
-            "description": "Stiahne aktuálnu mapu kosenia z Bosch Cloud API a uloží ju lokálne ako \"www/indego_map_base.svg\". Mapa odráža naposledy zaznamenú trasu kosenia.",
+            "description": "Stiahne aktuálnu mapu kosenia z Bosch Cloud API a uloží ju lokálne ako \"www/indego_map_base.svg\". Mapa odráža naposledy zaznamenanú trasu kosenia.",
             "fields": {
                 "mower_serial": {
-                    "description": "Sériové číslo kosačky. Potrebné iba vtedy, keď máte nakonfigurovaných viacero kosačiek.",
-                    "name": "Sériové číslo"
+                    "name": "Sériové číslo",
+                    "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
+                "mower_entity": {
+                    "name": "Entita",
+                    "description": "Vyberte entitu kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
                 }
             }
         },
         "set_calendar_slot": {
-            "name": "Aktivovať/deaktivovať časový slot kalendára",
-            "description": "Upraviť časový slot kalendára (zmeniť časy, aktivovať alebo deaktivovať)",
+            "name": "Nastaviť slot kalendára",
+            "description": "Nastaví slot kalendára, keď používate manuálny plán namiesto SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Sériové číslo",
                     "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
                 },
-                "calendar_type": {
-                    "name": "Typ kalendára",
-                    "description": "Vyberte kalendár ('calendar' pre manuálny kalendár alebo 'predictive' pre deaktivované časové obdobia v režime SmartMowing)."
+                "mower_entity": {
+                    "name": "Entita",
+                    "description": "Vyberte entitu kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
                 },
                 "days": {
-                    "name": "Deň",
-                    "description": "Názov dňa v týždni, ktorý sa má nakonfigurovať."
+                    "name": "Dni",
+                    "description": "Ktorý deň v týždni sa má nakonfigurovať."
                 },
                 "slot": {
-                    "name": "Časový slot",
-                    "description": "Ktorý časový slot sa má zmeniť (1 alebo 2)."
+                    "name": "Slot",
+                    "description": "Ktorý slot vybraného dňa sa má nakonfigurovať (1 alebo 2)."
                 },
                 "enabled": {
                     "name": "Aktivovať/deaktivovať",
-                    "description": "Aktivovať alebo deaktivovať vybraný deň/časový slot."
+                    "description": "Či má byť vybraný slot aktivovaný alebo deaktivovaný."
                 },
                 "start": {
-                    "name": "Začiatok",
-                    "description": "Čas začiatku vybraného slotu. Vyžaduje sa iba v prípade, že sa má slot aktivovať. Použijú sa iba hodiny a minúty."
+                    "name": "Čas začiatku",
+                    "description": "Nastavte čas začiatku pre vybraný slot a deň. Vyžaduje sa iba vtedy, ak chcete aktivovať slot. Používajú sa iba hodiny a minúty."
                 },
                 "end": {
-                    "name": "Koniec",
-                    "description": "Čas ukončenia vybraného slotu. Vyžaduje sa iba v prípade, že sa má slot aktivovať. Použijú sa iba hodiny a minúty."
-                }
-            }
-        },
-        "set_bump_sensitivity": {
-            "name": "Nastaviť podmienky trávnika kosačky",
-            "description": "Nastaviť podmienky trávnika kosačky",
-            "fields": {
-                "mower_serial": {
-                    "name": "Sériové číslo",
-                    "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
-                },
-                "bump_sensitivity": {
-                    "name": "Podmienky trávnika",
-                    "description": "Podmienky trávnika kosačky"
-                }
-            }
-        },
-        "set_pin": {
-            "name": "PIN kód",
-            "description": "Zmeniť PIN kód kosačky",
-            "fields": {
-                "mower_serial": {
-                    "name": "Sériové číslo",
-                    "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
-                },
-                "pin": {
-                    "name": "PIN kód",
-                    "description": "Nový štvorciferný PIN kód kosačky"
+                    "name": "Čas ukončenia",
+                    "description": "Nastavte čas ukončenia pre vybraný slot a deň. Vyžaduje sa iba vtedy, ak chcete aktivovať slot. Používajú sa iba hodiny a minúty."
                 }
             }
         },
         "set_predictive_mowing_window": {
-            "name": "Nastaviť časové okno SmartMowing",
-            "description": "Časové okno, počas ktorého môže kosačka kosiť v režime SmartMowing.",
+            "name": "Nastaviť okno SmartMowing",
+            "description": "Nastaví povolené okno kosenia pre SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Sériové číslo",
                     "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
                 },
+                "mower_entity": {
+                    "name": "Entita",
+                    "description": "Vyberte entitu kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
                 "earliest_start": {
                     "name": "Najskorší štart",
-                    "description": "Najskorší čas, kedy má kosačka začať."
+                    "description": "Najskorší čas, kedy môže SmartMowing kosiť. Používajú sa iba hodiny a minúty."
                 },
                 "latest_end": {
                     "name": "Najneskorší koniec",
-                    "description": "Najneskorší čas, kedy má kosačka skončiť."
+                    "description": "Najneskorší čas, kedy môže SmartMowing kosiť. Používajú sa iba hodiny a minúty."
+                }
+            }
+        },
+        "set_bump_sensitivity": {
+            "name": "Nastaviť podmienky trávnika",
+            "description": "Nastavuje citlivosť kosačky na nárazy.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Sériové číslo",
+                    "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
+                "mower_entity": {
+                    "name": "Entita",
+                    "description": "Vyberte entitu kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
+                "bump_sensitivity": {
+                    "name": "Podmienky trávnika",
+                    "description": "Citlivosť kosačky na nárazy."
+                }
+            }
+        },
+        "set_pin": {
+            "name": "Zmeniť PIN kód",
+            "description": "Zmení PIN kód kosačky.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Sériové číslo",
+                    "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
+                "mower_entity": {
+                    "name": "Entita",
+                    "description": "Vyberte entitu kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
+                "pin": {
+                    "name": "PIN kód",
+                    "description": "Nový 4-ciferný PIN kód pre kosačku."
                 }
             }
         }

--- a/custom_components/indego/translations/sk.json
+++ b/custom_components/indego/translations/sk.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Režim kosenia",
                 "state": {
-                    "Calendar": "Manuálny kalendár"
+                    "calendar": "Manuálny kalendár"
                 }
             },
             "runtime_total": {
@@ -873,7 +873,7 @@
         "command_options": {
             "options": {
                 "mow": "Kosiť",
-                "returnToDock": "Návrat do dokovacej stanice",
+                "return_to_dock": "Návrat do dokovacej stanice",
                 "pause": "Pauza"
             }
         },

--- a/custom_components/indego/translations/sv.json
+++ b/custom_components/indego/translations/sv.json
@@ -647,77 +647,101 @@
     "services": {
         "command": {
             "name": "Skicka kommando",
-            "description": "Skicka kommandon till gräsklipparen. Välj ett kommando.",
+            "description": "Skickar ett styrkommando till gräsklipparen. Giltiga kommandon är \"mow\" (starta klippning), \"returnToDock\" (återvänd till laddstationen) och \"pause\" (pausa klippningen).",
             "fields": {
                 "mower_serial": {
-                    "description": "Gräsklippare serienummer. Krävs endast när du har flera gräsklippare konfigurerade.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Välj gräsklipparentiteten. Krävs endast om flera gräsklippare är konfigurerade."
                 },
                 "command": {
-                    "name": "Skicka kommando",
-                    "description": "Skicka kommandon till gräsklipparen. Välj ett kommando."
+                    "name": "Kommando",
+                    "description": "Kommando som ska skickas till gräsklipparen."
                 }
             }
         },
         "smartmowing": {
             "name": "Slå SmartMowing på/av",
-            "description": "Aktivera eller inaktivera SmartMowing. Tillåtna värden är true eller false.",
+            "description": "Aktiverar eller inaktiverar SmartMowing-funktionen, som automatiskt justerar klippschemat baserat på väderförhållanden och grästillväxt.",
             "fields": {
                 "mower_serial": {
-                    "description": "Gräsklippare serienummer. Krävs endast när du har flera gräsklippare konfigurerade.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Välj gräsklipparentiteten. Krävs endast om flera gräsklippare är konfigurerade."
                 },
                 "enable": {
-                    "description": "Aktivera SmartMowing.",
-                    "name": "Aktivera/inaktivera"
+                    "name": "Aktivera/inaktivera",
+                    "description": "Ställer in SmartMowing-statusen. Använd \"true\" för att aktivera eller \"false\" för att inaktivera funktionen."
                 }
             }
         },
         "delete_alert": {
             "name": "Ta bort varning",
-            "description": "Radera den valda aviseringen.",
+            "description": "Tar bort en specifik avisering baserat på dess index. Index 0 avser den senaste aviseringen.",
             "fields": {
                 "mower_serial": {
-                    "description": "Gräsklippare serienummer. Krävs endast när du har flera gräsklippare konfigurerade.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Välj gräsklipparentiteten. Krävs endast om flera gräsklippare är konfigurerade."
                 },
                 "alert_index": {
-                    "description": "Radera den valda aviseringen. 0 för den senaste aviseringen.",
-                    "name": "Aviseringsindex"
+                    "name": "Aviseringsindex",
+                    "description": "Index för aviseringen som ska tas bort. 0 = senaste, 1 = näst senaste, osv."
                 }
             }
         },
         "delete_alert_all": {
             "name": "Ta bort alla varningar",
-            "description": "Radera alla aviseringar.",
+            "description": "Tar bort alla befintliga aviseringar för gräsklipparen på en gång.",
             "fields": {
                 "mower_serial": {
-                    "description": "Gräsklippare serienummer. Krävs endast när du har flera gräsklippare konfigurerade.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Välj gräsklipparentiteten. Krävs endast om flera gräsklippare är konfigurerade."
                 }
             }
         },
         "read_alert": {
             "name": "Markera varning som läst",
-            "description": "Markera den valda aviseringen som läst.",
+            "description": "Markerar en specifik avisering som läst baserat på dess index. Index 0 avser den senaste aviseringen.",
             "fields": {
                 "mower_serial": {
-                    "description": "Gräsklippare serienummer. Krävs endast när du har flera gräsklippare konfigurerade.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Välj gräsklipparentiteten. Krävs endast om flera gräsklippare är konfigurerade."
                 },
                 "alert_index": {
-                    "description": "Markera den valda aviseringen som läst. 0 för den senaste aviseringen.",
-                    "name": "Aviseringsindex"
+                    "name": "Aviseringsindex",
+                    "description": "Index för aviseringen som ska markeras som läst. 0 = senaste, 1 = näst senaste, osv."
                 }
             }
         },
         "read_alert_all": {
             "name": "Markera alla varningar som lästa",
-            "description": "Markera alla aviseringar som lästa.",
+            "description": "Markerar alla befintliga aviseringar för gräsklipparen som lästa.",
             "fields": {
                 "mower_serial": {
-                    "description": "Gräsklippare serienummer. Krävs endast när du har flera gräsklippare konfigurerade.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Välj gräsklipparentiteten. Krävs endast om flera gräsklippare är konfigurerade."
                 }
             }
         },
@@ -726,88 +750,104 @@
             "description": "Hämtar den aktuella klippkartan från Bosch Cloud API och sparar den lokalt som \"www/indego_map_base.svg\". Kartan återspeglar den senast registrerade klippvägen.",
             "fields": {
                 "mower_serial": {
-                    "description": "Gräsklippare serienummer. Krävs endast när du har flera gräsklippare konfigurerade.",
-                    "name": "Serienummer"
+                    "name": "Serienummer",
+                    "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Välj gräsklipparentiteten. Krävs endast om flera gräsklippare är konfigurerade."
                 }
             }
         },
         "set_calendar_slot": {
-            "name": "Aktivera/inaktivera kalenderintervall",
-            "description": "Ändra ett kalenderintervall (ändra tider, aktivera eller inaktivera)",
+            "name": "Ställ in kalenderslot",
+            "description": "Ställer in en kalenderslot när du använder ett manuellt schema istället för SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
                     "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
                 },
-                "calendar_type": {
-                    "name": "Kalendertyp",
-                    "description": "Välj kalender ('calendar' för den manuella kalendern eller 'predictive' för inaktiverade tidsperioder i SmartMowing-läge)."
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Välj gräsklipparentiteten. Krävs endast om flera gräsklippare är konfigurerade."
                 },
                 "days": {
-                    "name": "Dag",
-                    "description": "Namnet på veckodagen som ska konfigureras."
+                    "name": "Dagar",
+                    "description": "Vilken dag i veckan som ska konfigureras."
                 },
                 "slot": {
-                    "name": "Tidsintervall",
-                    "description": "Vilket tidsintervall som ska ändras (1 eller 2)."
+                    "name": "Slot",
+                    "description": "Vilken slot för den valda dagen som ska konfigureras (1 eller 2)."
                 },
                 "enabled": {
                     "name": "Aktivera/inaktivera",
-                    "description": "Aktivera eller inaktivera vald dag/tidsintervall."
+                    "description": "Om den valda sloten ska aktiveras eller inaktiveras."
                 },
                 "start": {
-                    "name": "Start",
-                    "description": "Starttid för valt tidsintervall. Krävs endast om tidsintervallet ska aktiveras. Endast timmar och minuter används."
+                    "name": "Starttid",
+                    "description": "Ange starttid för vald slot och dag. Behövs endast om du vill aktivera en slot. Endast timme och minut används."
                 },
                 "end": {
-                    "name": "Slut",
-                    "description": "Sluttid för valt tidsintervall. Krävs endast om tidsintervallet ska aktiveras. Endast timmar och minuter används."
-                }
-            }
-        },
-        "set_bump_sensitivity": {
-            "name": "Ange gräsförhållanden för klipparen",
-            "description": "Ange gräsförhållandena för klipparen",
-            "fields": {
-                "mower_serial": {
-                    "name": "Serienummer",
-                    "description": "Klipparens serienummer. Krävs endast om flera klippare är konfigurerade."
-                },
-                "bump_sensitivity": {
-                    "name": "Gräsförhållanden",
-                    "description": "Gräsförhållanden för klipparen"
-                }
-            }
-        },
-        "set_pin": {
-            "name": "PIN-kod",
-            "description": "Ändra gräsklipparens PIN-kod",
-            "fields": {
-                "mower_serial": {
-                    "name": "Serienummer",
-                    "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
-                },
-                "pin": {
-                    "name": "PIN-kod",
-                    "description": "Ny fyrsiffrig PIN-kod för gräsklipparen"
+                    "name": "Sluttid",
+                    "description": "Ange sluttid för vald slot och dag. Behövs endast om du vill aktivera en slot. Endast timme och minut används."
                 }
             }
         },
         "set_predictive_mowing_window": {
             "name": "Ställ in SmartMowing-tidsfönster",
-            "description": "Tidsfönstret då gräsklipparen får klippa i SmartMowing-läge.",
+            "description": "Ställer in det tillåtna klippfönstret för SmartMowing.",
             "fields": {
                 "mower_serial": {
                     "name": "Serienummer",
                     "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
                 },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Välj gräsklipparentiteten. Krävs endast om flera gräsklippare är konfigurerade."
+                },
                 "earliest_start": {
                     "name": "Tidigaste start",
-                    "description": "Den tidigaste tiden gräsklipparen ska börja."
+                    "description": "Tidigaste tidpunkt då SmartMowing får klippa. Endast timmar och minuter används."
                 },
                 "latest_end": {
                     "name": "Senaste slut",
-                    "description": "Den senaste tiden gräsklipparen ska sluta."
+                    "description": "Senaste tidpunkt då SmartMowing får klippa. Endast timmar och minuter används."
+                }
+            }
+        },
+        "set_bump_sensitivity": {
+            "name": "Ställ in gräsförhållanden",
+            "description": "Ställer in klipparens stötkänslighet.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Välj gräsklipparentiteten. Krävs endast om flera gräsklippare är konfigurerade."
+                },
+                "bump_sensitivity": {
+                    "name": "Gräsförhållanden",
+                    "description": "Klipparens stötkänslighet."
+                }
+            }
+        },
+        "set_pin": {
+            "name": "Ändra PIN-kod",
+            "description": "Ändrar klipparens PIN-kod.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
+                },
+                "mower_entity": {
+                    "name": "Entitet",
+                    "description": "Välj gräsklipparentiteten. Krävs endast om flera gräsklippare är konfigurerade."
+                },
+                "pin": {
+                    "name": "PIN-kod",
+                    "description": "Ny 4-siffrig PIN-kod för gräsklipparen."
                 }
             }
         }

--- a/custom_components/indego/translations/sv.json
+++ b/custom_components/indego/translations/sv.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Klippläge",
                 "state": {
-                    "Calendar": "Manuell kalender"
+                    "calendar": "Manuell kalender"
                 }
             },
             "runtime_total": {
@@ -873,7 +873,7 @@
         "command_options": {
             "options": {
                 "mow": "Klipp gräs",
-                "returnToDock": "Återvänd till laddstationen",
+                "return_to_dock": "Återvänd till laddstationen",
                 "pause": "Paus"
             }
         },


### PR DESCRIPTION
Introduces an optional `mower_entity` parameter for all Indego services and resolves service calls by entity ID, making multi-mower setups easier and less error-prone than serial-only targeting. It also updates `services.yaml` and all locale files with the new field, clearer service/field wording, corrected examples/selectors, and additional state translations (including mowing mode and last error mappings).