### PR TITLE
Fix OAuth transient error handling during token refresh

### DIFF
--- a/custom_components/indego/api.py
+++ b/custom_components/indego/api.py
@@ -46,9 +46,7 @@ class IndegoOAuth2Session(OAuth2Session):
             return
 
         if time.monotonic() < self._token_refresh_backoff_until:
-            raise OAuth2TokenRequestTransientError(
-                "OAuth token refresh is temporarily in backoff"
-            )
+            raise OAuth2TokenRequestTransientError()
 
         async with self._indego_refresh_lock:
             # Another coroutine may have refreshed the token while
@@ -57,9 +55,7 @@ class IndegoOAuth2Session(OAuth2Session):
                 return
 
             if time.monotonic() < self._token_refresh_backoff_until:
-                raise OAuth2TokenRequestTransientError(
-                    "OAuth token refresh is temporarily in backoff"
-                )
+                raise OAuth2TokenRequestTransientError()
 
             try:
                 await super().async_ensure_token_valid()


### PR DESCRIPTION
## Summary

Fixes an exception caused by the OAuth token refresh backoff handling.

`OAuth2TokenRequestTransientError` does not accept a message argument in Home Assistant. During an active token refresh backoff, the integration previously raised it with a custom message, resulting in:

`OAuth2TokenRequestTransientError.__init__() takes 1 positional argument but 2 were given`

## Changes

- Raise `OAuth2TokenRequestTransientError()` without a message during the OAuth backoff period.
- Keep the existing 60-second backoff behavior unchanged.
- Prevent the resulting `TypeError` from being propagated to Indego API update tasks.

The OAuth backoff itself was already working as intended; this only fixes how the transient exception is raised while the backoff is active.